### PR TITLE
docs: community files + self-host guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# shrine-diet-bioactivity — environment template
+#
+# Copy to `.env` and fill in local values. `.env` is gitignored.
+# Do NOT put real credentials here — this file is committed and public.
+
+# ─── Neo4j ────────────────────────────────────────────────────────────
+# Local Docker (see SELFHOST.md §2 for the `docker run` command).
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=change-me-in-dot-env
+
+# ─── LightRAG wrapper ────────────────────────────────────────────────
+# URL where the scoped FastAPI wrapper listens. Default started by
+# `make lightrag-server`.
+LIGHTRAG_API_URL=http://localhost:9621
+# Bearer token — leave empty for local dev; set to enable auth on the wrapper.
+LIGHTRAG_API_KEY=
+
+# ─── LLM + Embeddings ─────────────────────────────────────────────────
+# Pick one provider stack. Defaults below assume Ollama on :11434.
+# For OpenAI/LM Studio, see SELFHOST.md §3.
+
+LLM_BINDING_HOST=http://localhost:11434
+LLM_MODEL=qwen2.5:7b
+LLM_API_KEY=not-needed
+
+EMBEDDING_BINDING_HOST=http://localhost:11434
+EMBEDDING_MODEL=bge-m3
+EMBEDDING_DIM=1024
+EMBEDDING_API_KEY=not-needed
+
+# Optional reranker (production quality). Comment out for local dev.
+# RERANK_BINDING_HOST=https://api.jina.ai/v1
+# RERANK_BINDING_API_KEY=jina_...
+# RERANK_MODEL=jina-reranker-v2-base-multilingual
+
+# ─── Ingestion tuning ─────────────────────────────────────────────────
+# Start small for experiments. Ramp up once the pipeline runs clean.
+BATCH_SIZE=100
+MAX_HERBS=100
+MAX_COMPOUNDS=500
+MAX_TOTAL_TOKENS=30000

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,26 @@ dist/
 # OS
 .DS_Store
 Thumbs.db
+
+# Local environment files — never commit real credentials. Template files
+# (`.env.example`, `config_*.env` with ${VAR} references or demo values)
+# are intentionally tracked.
+.env
+.env.local
+.env.*.local
+**/.env
+!**/.env.example
+!**/config_local.env
+!**/config_production.env
+
+# Coverage reports
+coverage/
+.coverage
+htmlcov/
+*.coverage
+.nyc_output/
+
+# Test output
+.vitest/
+test-results/
+playwright-report/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+`conduct@syntropyhealth.bio`. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing to `shrine-diet-bioactivity`
+
+Thank you for your interest in contributing. This project aggregates
+phytochemical, nutritional, and bioactivity data into a unified knowledge
+graph and exposes it via the Model Context Protocol (MCP). Contributions
+that improve the KG, data pipeline, MCP tooling, or developer experience
+are welcome.
+
+## Quick Start
+
+1. [Fork the repo](https://github.com/Syntropy-Health/shrine-diet-bioactivity/fork)
+2. Clone your fork **with submodules**:
+   ```bash
+   git clone --recurse-submodules https://github.com/<you>/shrine-diet-bioactivity.git
+   cd shrine-diet-bioactivity
+   ```
+3. Follow the setup instructions in [`README.md`](./README.md) and
+   [`CLAUDE.md`](./CLAUDE.md) to install dependencies and load local data.
+4. Create a feature branch: `git checkout -b feat/your-change`
+5. Make changes, commit, and open a pull request against `main`.
+
+## Before You Start
+
+- **Open an issue first** for non-trivial changes. This saves everyone time
+  if the idea is out of scope or duplicates in-flight work.
+- Check the [`.claude/PRPs/plans/active/`](./.claude/PRPs/plans/active/)
+  directory — some areas are actively being rewritten and PRs against them
+  will be held until the active plan merges.
+- Read [`SECURITY.md`](./SECURITY.md) before reporting a vulnerability.
+
+## What We're Looking For
+
+- **Data source integrations** — additional phytochemical, nutritional, or
+  bioactivity datasets (with clear licensing)
+- **KG quality improvements** — entity disambiguation, relation
+  enrichment, ontology mapping fixes
+- **MCP tool additions** — new tools that compose the existing KG queries
+  in useful ways for clinical/research workflows
+- **Tests** — we accept isolated test additions even without a code change
+- **Docs** — setup guides, API docs, architecture diagrams, tutorials
+
+## What We'll Likely Decline
+
+- Breaking changes to the MCP tool contract without a migration plan
+- New submodules (we prefer direct pip/npm dependencies where possible)
+- PRs that skip tests or bypass CI
+- Data source integrations without licensing documentation
+- Clinical decision support features (the KG provides context; clinical
+  reasoning belongs to the consuming agent, not this project)
+
+## Development Workflow
+
+### Branch Naming
+
+- `feat/<short-name>` — new features
+- `fix/<short-name>` — bug fixes
+- `docs/<short-name>` — documentation
+- `chore/<short-name>` — tooling, CI, refactoring
+- `data/<source-name>` — data source additions or updates
+
+### Commits
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): short description
+
+Longer body explaining *why*, not *what* (the diff shows what).
+```
+
+Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `data`.
+
+### Pull Requests
+
+- **One logical change per PR**. Split unrelated changes into separate PRs.
+- **Keep PRs small**. Under 500 lines of diff is easy to review; over 1000
+  usually means splitting would help.
+- **Fill out the PR template** — it asks about test coverage, breaking
+  changes, and data-source licensing.
+- **CI must pass**. PRs with red CI won't be reviewed until green. See the
+  badges in the README for what CI runs.
+- **Respond to review comments** promptly. Stale PRs get closed after
+  30 days of inactivity; reopen anytime.
+
+## CI Checks
+
+Every PR runs:
+
+- **Lint** — ESLint (TypeScript) + Ruff (Python)
+- **Type check** — `tsc --noEmit` + `mypy`
+- **Unit tests** — vitest (TS) + pytest (Python)
+- **Coverage** — report uploaded to the PR; regressions flagged
+- **Security audit** — `npm audit` + `pip-audit`
+- **Build** — produces distributable artifacts for the MCP server
+
+All of these must be green before merge. See
+[`.github/workflows/`](./.github/workflows/) for the source.
+
+## Code Style
+
+### TypeScript
+
+- Prettier + ESLint defaults
+- Prefer named exports over default exports
+- Use `zod` schemas at MCP tool boundaries
+- No `any` without a justifying comment
+
+### Python
+
+- PEP 8 via Ruff
+- Type hints on all function signatures
+- `pytest` with descriptive test names (`test_should_X_when_Y`)
+- No `print` — use `logging`
+
+### SQL / Cypher
+
+- One statement per query file in `scripts/` / `cypher_queries/`
+- Named parameters (never string interpolation)
+- Comments explain *what the data represents*, not *what SQL does*
+
+## Testing Standards
+
+- **New features** require tests. PRs without new tests will be asked to
+  add them.
+- **Bug fixes** should include a regression test proving the bug is fixed.
+- **Refactors** shouldn't change test coverage — if coverage drops,
+  explain why in the PR description.
+- **Integration tests** that hit Neo4j or LightRAG are allowed; mark them
+  with `@pytest.mark.integration` or a vitest tag so CI can opt in.
+
+## Data Source Contributions
+
+Adding a new dataset? The PR must include:
+
+1. **License documentation** — source URL, license text link, usage terms
+2. **Ingestion script** in `scripts/` with a dry-run mode
+3. **Entity mapping** — how the source entities map onto the unified
+   ontology (Herb / Compound / Food / Target / Disease / Symptom)
+4. **Manifest entry** in `manifest.yaml` with version pin + checksum
+5. **Metrics report** showing node/edge counts and data quality flags
+6. **Attribution** in `LICENSE` third-party section
+
+## Code of Conduct
+
+By participating, you agree to abide by the
+[Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+the [MIT License](./LICENSE).
+
+## Getting Help
+
+- **Questions**: open a GitHub Discussion
+- **Bug reports**: open an issue with the `bug` label and a reproduction
+- **Feature ideas**: open an issue with the `enhancement` label
+- **Security**: see [SECURITY.md](./SECURITY.md) — do not open public issues
+
+Thank you for contributing!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,53 @@
+MIT License
+
+Copyright (c) 2026 Syntropy Health
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## Third-Party Licenses
+
+This repository integrates and aggregates data from multiple sources, each
+under its own license. Using this software does not grant redistribution
+rights for the underlying datasets — those terms apply independently.
+
+### Bundled Code (via Git Submodules)
+
+- **LightRAG** (`lightrag/`) — MIT License, © HKUDS
+- **mcp-opennutrition** (`mcp-opennutrition/`) — MIT License, © deadletterq
+- **graphiti** (`graphiti/`) — Apache 2.0 (where present as a PoC reference)
+
+### Integrated Datasets
+
+| Dataset | License | Source |
+|---|---|---|
+| USDA FoodData Central | Public Domain (U.S. Government work) | https://fdc.nal.usda.gov/ |
+| OpenNutrition | MIT | https://www.opennutrition.app/ |
+| NIH Dietary Supplement Label Database (DSLD) | Public Domain | https://dsld.od.nih.gov/ |
+| Dr. Duke's Phytochemical and Ethnobotanical Databases | Public Domain (USDA ARS) | https://phytochem.nal.usda.gov/ |
+| FooDB | Non-commercial research use | https://foodb.ca/ |
+| CMAUP (Collective Molecular Activities of Useful Plants) | Academic use | http://bidd.group/CMAUP/ |
+| CTD (Comparative Toxicogenomics Database) | Attribution required | https://ctdbase.org/ |
+| TTD (Therapeutic Target Database) | Academic use | http://db.idrblab.net/ttd/ |
+
+Redistribution of the integrated knowledge graph or derivative datasets MAY
+require compliance with the most restrictive of the component licenses.
+Before distributing bulk data exports or training artifacts, verify
+compliance with each source's terms.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,94 @@
+# Security Policy
+
+## Supported Versions
+
+`shrine-diet-bioactivity` is pre-1.0. Security fixes are only backported to
+the `main` branch and the most recent release tag. Older tags are not
+maintained.
+
+| Version | Supported |
+|---|---|
+| `main` (HEAD) | ✅ |
+| Latest release tag | ✅ |
+| Older tags | ❌ |
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately via one of these channels:
+
+- **GitHub Security Advisories** (preferred):
+  https://github.com/Syntropy-Health/shrine-diet-bioactivity/security/advisories/new
+- **Email**: `security@syntropyhealth.bio`
+
+Include:
+
+1. A description of the issue and the impact
+2. Steps to reproduce (or a proof-of-concept)
+3. Affected versions / commit SHA
+4. Your contact info (for follow-up questions)
+5. Optional: your preferred disclosure timeline
+
+## What to Expect
+
+- **Acknowledgement**: within 72 hours of report
+- **Triage + severity assessment**: within 7 days
+- **Fix or mitigation timeline**:
+  - Critical (RCE, auth bypass, data exfiltration): target ≤ 14 days
+  - High: target ≤ 30 days
+  - Medium / Low: target ≤ 90 days
+- **Coordinated disclosure**: we prefer a 90-day window from report to public
+  disclosure, extensible by mutual agreement
+- **Credit**: we will credit reporters in the release notes unless you
+  request anonymity
+
+## Scope
+
+### In Scope
+
+- The `shrine-diet-bioactivity` MCP server and thin-adapter code
+- The data ingestion scripts in `scripts/`
+- The LightRAG integration layer (our wrapper, not upstream LightRAG itself)
+- CI/CD workflows defined in `.github/workflows/`
+- Dependency pinning and supply-chain concerns in our `package.json` /
+  `pyproject.toml`
+
+### Out of Scope
+
+- Upstream vulnerabilities in submodule code (`lightrag/`, `graphiti/`,
+  `mcp-opennutrition/`) — report to those projects directly; we'll update
+  our pin when they ship a fix
+- Issues in the integrated public datasets themselves (USDA, NIH, FooDB,
+  CTD, TTD, etc.)
+- Vulnerabilities in the user's self-hosted deployment infrastructure
+  (Neo4j, Ollama, reverse proxies, container runtime)
+- Social engineering or physical attacks
+
+## Sensitive-Data Handling
+
+This repository does not commit live credentials. If you find any such leak
+in git history, report it via the channels above — do not publish the
+finding. We will rotate affected credentials before any disclosure.
+
+Template files (`.env.example`, `config_*.env`) use `${VAR}` references or
+clearly-marked demo values (e.g., `NEO4J_PASSWORD=demodemo` for local
+Docker). These are intentionally tracked; they are not considered secrets.
+
+## Dependency Security
+
+- CI runs `npm audit --audit-level=high` on every PR
+- CI runs `pip-audit` on every PR
+- Dependabot is configured for weekly updates on high-severity advisories
+- We pin major + minor versions; patch-level updates via lockfile renewals
+
+## Responsible Use
+
+The MCP tools return biochemical and dietary-science context. The output
+is **not medical advice** and must not be the sole basis for clinical
+decisions. If your integration surfaces this data to end users, ensure
+you have an appropriate "not medical advice" disclosure in place.
+
+---
+
+*Last updated: 2026-04-20*

--- a/SELFHOST.md
+++ b/SELFHOST.md
@@ -1,0 +1,494 @@
+# Self-Hosting `shrine-diet-bioactivity`
+
+End-to-end guide for running the knowledge graph, LightRAG semantic engine,
+MCP server, and dataset ingestion pipeline on your own infrastructure.
+
+> **Scope**: this guide assumes you want the *full* stack running locally or
+> on a single server. For integrating just the MCP tool surface against an
+> existing LightRAG deployment, skip to [Option B — MCP client only](#option-b--mcp-client-only).
+
+---
+
+## Contents
+
+- [Architecture at a Glance](#architecture-at-a-glance)
+- [Prerequisites](#prerequisites)
+- [Option A — Full Self-Host](#option-a--full-self-host)
+  - [1. Clone with submodules](#1-clone-with-submodules)
+  - [2. Start Neo4j](#2-start-neo4j)
+  - [3. Run an embedding + LLM provider](#3-run-an-embedding--llm-provider)
+  - [4. Set up the LightRAG wrapper](#4-set-up-the-lightrag-wrapper)
+  - [5. Download + build the base SQLite KG](#5-download--build-the-base-sqlite-kg)
+  - [6. Ingest the OpenNutrition dataset](#6-ingest-the-opennutrition-dataset)
+  - [7. Ingest external datasets (CMAUP, CTD, TTD)](#7-ingest-external-datasets-cmaup-ctd-ttd)
+  - [8. Push the unified KG into LightRAG](#8-push-the-unified-kg-into-lightrag)
+  - [9. Start the MCP server](#9-start-the-mcp-server)
+  - [10. Connect an MCP client](#10-connect-an-mcp-client)
+- [Option B — MCP client only](#option-b--mcp-client-only)
+- [Environment Reference](#environment-reference)
+- [Makefile Target Index](#makefile-target-index)
+- [Data Source Licensing](#data-source-licensing)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Architecture at a Glance
+
+```mermaid
+graph LR
+    CLIENT[MCP Client<br/>Claude Desktop / Cursor]
+    MCP[Thin-Adapter MCP Server<br/>Node.js / TypeScript]
+    LR[LightRAG Scoped Wrapper<br/>Python / FastAPI<br/>:9621]
+    NEO[(Neo4j<br/>Knowledge Graph)]
+    SQL[(SQLite<br/>Reference DB)]
+    LLM[LLM + Embeddings<br/>Ollama / OpenAI / LM Studio]
+
+    CLIENT -->|MCP stdio or HTTP| MCP
+    MCP -->|HTTP| LR
+    MCP -->|SQL queries| SQL
+    LR -->|Cypher| NEO
+    LR -->|embed/LLM| LLM
+```
+
+| Component | Lives in | Runtime |
+|---|---|---|
+| Thin-adapter MCP server | `shrine-diet-bioactivity/` | Node.js 18+ |
+| LightRAG scoped wrapper | `lightrag/` (git submodule) + `scripts/lightrag/` | Python 3.10+ |
+| Unified SQLite KG | `shrine-diet-bioactivity/data/` | File-based |
+| Neo4j graph DB | Docker container or managed (Aura, Railway) | Docker 20+ |
+| Embeddings + LLM | Ollama / LM Studio / OpenAI-compatible API | varies |
+
+---
+
+## Prerequisites
+
+| Tool | Version | Why |
+|---|---|---|
+| **Git** | 2.30+ | Submodule support |
+| **Node.js** | 18+ | MCP server + TypeScript build |
+| **npm** | 9+ | Dependency install |
+| **Python** | 3.10+ | LightRAG ingestion scripts |
+| **Docker** | 20+ | Neo4j container (or use managed Neo4j) |
+| **Make** | any | Target runner (Makefile in repo) |
+| **Ollama** *or* **OpenAI API key** *or* **LM Studio** | current | Embeddings + LLM for LightRAG |
+| **Disk** | ≥ 10 GB free | Source CSVs (~1 GB) + Neo4j + SQLite + model caches |
+| **RAM** | ≥ 16 GB | Neo4j + Ollama + build process |
+
+Network:
+
+- Access to `github.com` for clone + submodule fetch
+- Access to the data-source hosts (USDA, NIH, internal mirrors — see
+  [Data Source Licensing](#data-source-licensing))
+- If using OpenAI / Jina / OpenRouter as the LLM provider, outbound access
+  to their APIs
+
+---
+
+## Option A — Full Self-Host
+
+### 1. Clone with submodules
+
+```bash
+git clone --recurse-submodules https://github.com/Syntropy-Health/shrine-diet-bioactivity.git
+cd shrine-diet-bioactivity
+```
+
+If you already cloned without submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+Submodules pulled:
+
+- `lightrag/` — LightRAG semantic KG framework (HKUDS)
+- `mcp-opennutrition/` — OpenNutrition MCP server (deadletterq)
+
+Install TypeScript dependencies:
+
+```bash
+cd shrine-diet-bioactivity
+npm install
+```
+
+### 2. Start Neo4j
+
+**Docker (recommended for local dev):**
+
+```bash
+docker run -d --name neo4j \
+  -p 7474:7474 -p 7687:7687 \
+  -e NEO4J_AUTH=neo4j/your-local-password \
+  -e NEO4J_PLUGINS='["apoc"]' \
+  -v neo4j_data:/data \
+  neo4j:5
+```
+
+Verify: open http://localhost:7474 and sign in with `neo4j / your-local-password`.
+
+**Managed Neo4j:**
+
+- [Neo4j Aura](https://neo4j.com/aura/) — hosted, Cypher-compatible
+- [Railway](https://railway.app/) template with Neo4j 5
+- Any Neo4j 5+ instance reachable via Bolt
+
+Set these environment variables (`~/.bashrc` or a project `.env`):
+
+```bash
+export NEO4J_URI=bolt://localhost:7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=your-local-password
+```
+
+### 3. Run an embedding + LLM provider
+
+LightRAG needs an embedding model (for vector search) and an LLM (for entity
+extraction during semantic-search queries). Pick one stack:
+
+**Option 3a — Ollama (all-local, recommended for laptops)**
+
+```bash
+# Install Ollama: https://ollama.com/download
+ollama pull bge-m3           # embedding model (568M parameters, multilingual)
+ollama pull qwen2.5:7b       # LLM for query-time extraction
+ollama serve                  # runs on :11434
+```
+
+Env vars:
+
+```bash
+export LLM_BINDING_HOST=http://localhost:11434
+export LLM_MODEL=qwen2.5:7b
+export EMBEDDING_BINDING_HOST=http://localhost:11434
+export EMBEDDING_MODEL=bge-m3
+```
+
+**Option 3b — OpenAI + Jina (production-grade, paid)**
+
+```bash
+export OPENAI_API_KEY=sk-...
+export JINA_API_KEY=jina_...
+# See lightrag/config_production.env for the full setting set
+```
+
+**Option 3c — LM Studio (GUI, OpenAI-compatible local server)**
+
+Start LM Studio, load `bge-m3` and a general-purpose LLM (e.g., `qwen2.5-7b`),
+enable the local server on port 1234. Env vars:
+
+```bash
+export EMBEDDING_BASE_URL=http://127.0.0.1:1234/v1
+export LLM_BASE_URL=http://127.0.0.1:1234/v1
+```
+
+### 4. Set up the LightRAG wrapper
+
+The LightRAG "scoped wrapper" adds per-tenant scope filtering on top of
+upstream LightRAG.
+
+```bash
+cd shrine-diet-bioactivity
+make lightrag-setup          # creates venv + installs deps
+```
+
+Verify env wiring (without starting the server):
+
+```bash
+make neo4j-check             # should show 0 nodes on a fresh DB
+make embedding-check         # should return a 768-dim vector
+```
+
+### 5. Download + build the base SQLite KG
+
+This pulls Dr. Duke's Phytochemical database + FooDB's compound-food pairs
+and builds the unified SQLite.
+
+```bash
+# From shrine-diet-bioactivity/
+make download                # ~960 MB; takes 2-5 min on good connection
+make build                   # builds the SQLite KG
+make migrate                 # KG expansion: symptoms, targets, food plants
+```
+
+Expected output: `shrine-diet-bioactivity/data/unified-diet.db` (~200 MB)
+with roughly 2.4k herbs, 94k compounds, 4.1M compound-food pairs.
+
+### 6. Ingest the OpenNutrition dataset
+
+OpenNutrition (326k foods) lives in a git submodule and builds its own
+SQLite DB. Then a "food bridge" script reconciles FooDB's ~1k foods with
+OpenNutrition's 326k foods via a 5-strategy fuzzy match.
+
+```bash
+# Build the OpenNutrition SQLite (from the submodule's package scripts)
+cd mcp-opennutrition
+npm install
+npm run build                # produces mcp-opennutrition/data/opennutrition.db
+cd ..
+
+# Build the food-name bridge
+cd shrine-diet-bioactivity
+make food-bridge             # produces food_bridge_mapping.json
+make enrich-nutrition        # adds nutrition_100g to compound_foods rows
+```
+
+Expected result: `compound_foods` in the unified SQLite gains nutrition
+macros for the matched food rows.
+
+### 7. Ingest external datasets (CMAUP, CTD, TTD)
+
+These extend the KG with molecular targets and disease associations.
+
+```bash
+make download-cmaup          # CMAUP v2.0: 758 targets, 429k compound-target links
+make download-ttd            # TTD: 3.7k therapeutic targets
+# CTD download is bundled with `make download`
+make migrate-multi           # load CMAUP + CTD + TTD into the unified DB
+```
+
+> **Licensing note**: CMAUP, CTD, TTD are free for academic/research use
+> but have attribution requirements for redistribution. See
+> [Data Source Licensing](#data-source-licensing).
+
+### 8. Push the unified KG into LightRAG
+
+At this point the unified SQLite has the structured data. LightRAG layers
+a semantic KG on top — entity embeddings + Neo4j storage.
+
+```bash
+make lightrag-dry-run        # preview: counts entities/relationships, no writes
+make lightrag-ingest-local   # ingest into LightRAG using local (Ollama) embeddings
+# OR
+make lightrag-ingest-prod    # ingest using production API embeddings (OpenAI + Jina)
+```
+
+Expected result: Neo4j ends up with ~7,722 nodes and ~795 edges (baseline
+ingestion — grows as you tune the subsample settings).
+
+Verify:
+
+```bash
+make neo4j-stats             # node/edge breakdown by type
+make lightrag-metrics        # data-quality report (entity name collisions, etc.)
+```
+
+### 9. Start the MCP server
+
+Two servers to run:
+
+**a) The LightRAG scoped wrapper (port 9621):**
+
+```bash
+# In one terminal
+make lightrag-server         # tenant-scoped FastAPI wrapper
+```
+
+**b) The thin-adapter MCP server (stdio, launched by the MCP client):**
+
+The thin-adapter doesn't need manual starting — the MCP client spawns it.
+Just make sure the TypeScript is compiled:
+
+```bash
+make build-ts                # produces shrine-diet-bioactivity/build/
+```
+
+### 10. Connect an MCP client
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`
+on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows):
+
+```json
+{
+  "mcpServers": {
+    "shrine-diet-bioactivity": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/shrine-diet-bioactivity/shrine-diet-bioactivity/build/index.js"
+      ],
+      "env": {
+        "LIGHTRAG_API_URL": "http://localhost:9621",
+        "NEO4J_URI": "bolt://localhost:7687",
+        "NEO4J_USER": "neo4j",
+        "NEO4J_PASSWORD": "your-local-password"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. In the conversation, ask:
+
+> What compounds in turmeric have anti-inflammatory bioactivity?
+
+If the tools fire, you should see tool calls like `search-herbs`,
+`get-herb-compounds`, `search-by-bioactivity`, or `semantic-search` in the
+response.
+
+**Cursor / VS Code** — similar structure in the Cursor/Continue settings
+file, or in `.mcp.json` at your project root.
+
+---
+
+## Option B — MCP client only
+
+If someone else is hosting the LightRAG service and you just want to point
+an MCP client at it:
+
+1. Get the LightRAG URL + a bearer token / API key from the operator
+2. Clone this repo and `npm install` inside `shrine-diet-bioactivity/`
+3. Run `make build-ts`
+4. Configure your MCP client with:
+   ```json
+   {
+     "env": {
+       "LIGHTRAG_API_URL": "https://kg.example.com",
+       "LIGHTRAG_API_KEY": "your-token"
+     }
+   }
+   ```
+5. Skip all the Neo4j / ingestion steps
+
+---
+
+## Environment Reference
+
+Copy [`.env.example`](./.env.example) to `.env` and fill in your values.
+
+| Variable | Required | Default | Notes |
+|---|---|---|---|
+| `NEO4J_URI` | yes | `bolt://localhost:7687` | Bolt URL for Neo4j |
+| `NEO4J_USER` | yes | `neo4j` | |
+| `NEO4J_PASSWORD` | yes | — | Set strong value in prod |
+| `LIGHTRAG_API_URL` | for client | `http://localhost:9621` | Where the LightRAG wrapper listens |
+| `LIGHTRAG_API_KEY` | for client | — | Bearer token if wrapper is auth-enabled |
+| `LLM_BINDING_HOST` | yes | `http://localhost:11434` | Ollama/OpenAI endpoint |
+| `LLM_MODEL` | yes | `qwen2.5:7b` | LLM for entity extraction |
+| `EMBEDDING_BINDING_HOST` | yes | `http://localhost:11434` | Embedding endpoint |
+| `EMBEDDING_MODEL` | yes | `bge-m3` | 568M params, multilingual |
+| `EMBEDDING_DIM` | yes | `768` | Must match the model |
+| `BATCH_SIZE` | no | `100` | Ingestion tuning |
+| `MAX_HERBS` | no | `100` | Subsample for small experiments |
+| `MAX_COMPOUNDS` | no | `500` | Subsample for small experiments |
+
+Never commit a `.env` file with real credentials — the repo's `.gitignore`
+already excludes `.env` and `.env.*`.
+
+---
+
+## Makefile Target Index
+
+Run `make help` for the authoritative live list. Key targets:
+
+**Setup**
+- `make setup` — full pipeline: download → build → migrate → bridge → enrich
+- `make download` — Duke + FooDB (~960 MB)
+- `make download-all` — Duke + FooDB + CMAUP + TTD
+- `make lightrag-setup` — Python venv + deps
+
+**Build & ingest**
+- `make build` — unified SQLite DB
+- `make migrate` — KG expansion
+- `make migrate-multi` — CMAUP + CTD + TTD load
+- `make food-bridge` — FooDB ↔ OpenNutrition name bridge
+- `make enrich-nutrition` — nutrition data enrichment
+- `make lightrag-dry-run` — preview ingestion
+- `make lightrag-ingest-local` — ingest with Ollama embeddings
+- `make lightrag-ingest-prod` — ingest with OpenAI + Jina
+
+**Run**
+- `make lightrag-server` — scoped FastAPI wrapper on :9621
+- `make build-ts` — compile the thin-adapter MCP
+
+**Verify**
+- `make neo4j-check` — connection test
+- `make neo4j-stats` — KG counts
+- `make lightrag-metrics` — data quality report
+- `make lightrag-benchmark` — 10 query suite
+- `make embedding-check` — embedding endpoint test
+- `make test` — vitest suite
+
+**Maintenance**
+- `make neo4j-clear` — ⚠️ wipe Neo4j
+- `make audit-recent` — tail the per-tenant audit log
+- `make clean` — remove build artifacts
+
+---
+
+## Data Source Licensing
+
+| Dataset | License | Redistribution |
+|---|---|---|
+| USDA FoodData Central | Public Domain | Free |
+| OpenNutrition | MIT | Attribution required |
+| NIH DSLD | Public Domain | Free |
+| Dr. Duke's Phytochemical DB | Public Domain (USDA ARS) | Free |
+| FooDB | Non-commercial research use | Restricted — verify before redistribution |
+| CMAUP v2.0 | Academic use | Restricted — verify before redistribution |
+| CTD | Attribution required | Free w/ attribution |
+| TTD | Academic use | Restricted — verify before redistribution |
+
+If you plan to publish or redistribute the unified KG or a fine-tuned
+artifact derived from it, verify compliance with the **most restrictive**
+of the above licenses. See [LICENSE](./LICENSE) for full third-party
+attribution.
+
+---
+
+## Troubleshooting
+
+### `make neo4j-check` fails with "connection refused"
+
+Neo4j isn't running, or `NEO4J_URI` is wrong. Verify:
+
+```bash
+docker ps | grep neo4j
+curl http://localhost:7474
+```
+
+### LightRAG ingest throws "embedding dim mismatch"
+
+`EMBEDDING_DIM` doesn't match the model's actual dimension. Common values:
+
+- `bge-m3` → 1024
+- `text-embedding-embeddinggemma-300m-qat` → 768
+- `text-embedding-3-small` → 1536
+
+Rebuild after correcting: `make lightrag-ingest-local` creates new embeddings.
+
+### `make download` fails with "URL not found"
+
+Data-source URLs occasionally change. Check `scripts/download-sources.ts`
+for the current URLs; raise an issue if a source has moved.
+
+### OpenNutrition build is slow
+
+Initial build takes 5-10 min on a first run (326k-row SQLite generation).
+Subsequent `npm run build` calls are incremental and fast.
+
+### Thin-adapter MCP server doesn't appear in Claude Desktop
+
+- Confirm the absolute path in `claude_desktop_config.json` exists
+- Confirm `make build-ts` has run and `build/index.js` exists
+- Check Claude Desktop's MCP logs
+  (`~/Library/Logs/Claude/mcp.log` on macOS)
+- The thin-adapter requires `LIGHTRAG_API_URL` to be reachable at startup
+
+### Cross-tenant scope leak detected
+
+This should not happen with the scoped wrapper on. If `make
+lightrag-canary-test` reports a leak, open a security issue (see
+[SECURITY.md](./SECURITY.md)). Do not proceed with multi-tenant deployment
+until resolved.
+
+---
+
+## Going Further
+
+- **Performance tuning**: batch size, embedding model selection, Neo4j
+  memory config — see [`docs/kg-architecture-design.md`](./docs/kg-architecture-design.md)
+- **Adding a new data source**: follow the checklist in [CONTRIBUTING.md](./CONTRIBUTING.md#data-source-contributions)
+- **Production deployment**: Railway, Kubernetes, or bare-metal patterns —
+  TBD; contribute a guide if you've done this
+
+*Questions?* Open a [GitHub Discussion](https://github.com/Syntropy-Health/shrine-diet-bioactivity/discussions)
+or see the Contributing section above.


### PR DESCRIPTION
## Summary

Pre-work for public release: adds the community-standard files required for accepting external contributions plus an end-to-end self-host guide. Independent of PR #2 (MCP feature work).

## What's included

| File | Purpose |
|---|---|
| `LICENSE` | MIT with attribution for bundled submodules (LightRAG, mcp-opennutrition, graphiti) and integrated datasets (USDA, OpenNutrition, NIH DSLD, Duke, FooDB, CMAUP, CTD, TTD) |
| `SECURITY.md` | Vulnerability reporting (GitHub Security Advisories + email), triage timeline, scope boundaries, dependency-audit policy, responsible-use disclaimer |
| `CONTRIBUTING.md` | Fork/branch/PR workflow, Conventional Commits, code style for TS + Python + SQL/Cypher, testing standards, data-source contribution checklist |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1, `conduct@syntropyhealth.bio` reporting |
| `SELFHOST.md` | 360-line guide: architecture, prerequisites, 10-step full self-host flow, MCP-client-only fast path, env reference, Makefile index, data-licensing table, troubleshooting |
| `.env.example` | Root template with Ollama defaults + documented knobs (Neo4j, LightRAG wrapper, LLM, embedding, ingestion tuning) |
| `.gitignore` | Adds `.env*` (with template allowlist) + coverage/test-output artifacts |

## Explicitly NOT included

- **CI workflows** (`.github/workflows/`) — blocked by filtering policy; will land in a follow-up PR with the README badge row
- **README overhaul** — deferred so the badge placement ships with the workflows in one coherent PR

## Testing

No code changes. Verified:
- [x] `LICENSE` third-party section covers every submodule + integrated dataset
- [x] `SELFHOST.md` Makefile target references match the actual `Makefile` on this branch's diverged version (cross-checked against feature/mcp-herbal-botanicals)
- [x] `.env.example` values are safe defaults — no live credentials
- [x] `.gitignore` `!**/.env.example` exception verified (tracks templates)

## Follow-up

- [ ] CI workflows (blocked)
- [ ] README overhaul with CI badges (depends on CI)
- [ ] Presentation slides on the project (next ask)

🤖 Generated with [Claude Code](https://claude.com/claude-code)