### PR TITLE
docs(kg): documentation index + KG completeness audit + RED gate tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Open-source nutrition and dietary supplement data sources for RAG-powered health applications.
 
+## 📚 Documentation index
+
+**Start here:** [`docs/INDEX.md`](docs/INDEX.md) — single source of navigation for the project, grouped by audience (newcomer / architect / data-engineer / researcher / clinical / ops).
+
+**KG completeness audit:** [`docs/KG_COMPLETENESS_AUDIT.md`](docs/KG_COMPLETENESS_AUDIT.md) — quantitative gap analysis vs the two priority use cases (Symptom→food, Diet→effects), with concrete TDD specs for the top three remediations.
+
 ## Overview
 
 This repository aggregates authoritative open-source nutrition databases for use in AI-powered dietary recommendation systems. It serves as the data foundation for the [Diet Insight Engine](https://github.com/Syntropy-Health/diet-insight-engine) and related Syntropy Health applications.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,131 @@
+# Documentation Index
+
+> Single source of navigation for the unified diet KG. Grouped by audience; each entry has a one-line description so you can locate the right doc in <30 seconds.
+>
+> **Last refreshed:** 2026-05-07. If you add a doc, link it here.
+
+---
+
+## TL;DR — what is this project?
+
+A **unified diet knowledge graph** spanning macronutrients, foods, herbs, phytochemical compounds, molecular targets, and diseases — aggregated from 7+ open-source datasets, indexed in Neo4j (graph + vector embeddings) via LightRAG, and queried by LLM agents through 5 thin-adapter MCP primitives.
+
+Primary use cases driving the design:
+- **A. Symptom → food.** Given a symptom, surface foods/herbs whose bioactives have evidence-graded drug-target activity for the implicated targets/diseases.
+- **D. Diet → predicted physiological effects.** Given a recorded diet (foods + portions), aggregate bioactive compound exposure → target modulation → predicted pathway/disease effects.
+- **C. Compound mechanism dossier** (free from the same backbone): unified evidence card for any bioactive (e.g. quercetin) — structure, drug-likeness, targets, pathways, food sources.
+
+---
+
+## Newcomer onboarding (read in this order)
+
+| File | One-line description |
+|---|---|
+| [`README.md`](../README.md) | Project elevator pitch + data sources table + entry points to install / setup |
+| [`CLAUDE.md`](../CLAUDE.md) | Repo layout, build commands, and convention guidance for AI-assisted development |
+| [`docs/RESEARCHER_GUIDE.md`](RESEARCHER_GUIDE.md) | How researchers should query the KG — persona-first usage manual |
+| [`docs/INDEX.md`](INDEX.md) | This file |
+
+---
+
+## Architecture & system design
+
+| File | One-line description |
+|---|---|
+| [`docs/unified-diet-kg-architecture.md`](unified-diet-kg-architecture.md) | Authoritative diagram of structured-vs-unstructured ingest, entity types, and query flows |
+| [`docs/kg-architecture-design.md`](kg-architecture-design.md) | Design rationale for SQLite + LightRAG + Neo4j three-tier architecture, including alternatives rejected |
+| [`docs/kg-ingestion-comparison.md`](kg-ingestion-comparison.md) | Comparison of ingest paths (`ainsert_custom_kg` vs LLM extraction) and when to use each |
+| [`docs/data-sources-catalog.md`](data-sources-catalog.md) | Per-dataset schema, file format, and join keys for Duke, FooDB, OpenNutrition, CMAUP, TTD, CTD, SymMap, HERB 2.0 |
+| [`docs/DATASET_PROVENANCE.md`](DATASET_PROVENANCE.md) | Per-source license, version pin, refresh cadence — the doc a paper reviewer reads |
+| [`shrine-diet-bioactivity/docs/integration-guide.md`](../shrine-diet-bioactivity/docs/integration-guide.md) | How the MCP thin-adapter integrates with downstream consumer apps |
+| [`mcp/README.md`](../mcp/README.md) | kg-mcp gateway: deployment URL, auth flow (static API key / Clerk JWT), tool catalog |
+
+---
+
+## Architectural Decision Records (ADRs)
+
+ADRs capture decisions that meaningfully shape the system; each is dated, justified, and lists alternatives considered.
+
+| ADR | Title |
+|---|---|
+| [0001](adr/0001-vector-storage-on-aura.md) | Vector storage on Neo4j Aura (vs separate vector DB) |
+| 0002–0006 | _Reserved — see git history; not yet captured as ADRs_ |
+| [0007](adr/0007-compound-identity-bridge.md) | Compound identity bridge + ChEMBL evidence layer (Phase 1 drug-bioactive) |
+
+> **Convention:** new ADRs use the next free number, never reuse a number. If a decision is reversed, write a new ADR that supersedes the old one (don't edit the old one).
+
+---
+
+## Active feature specs & plans
+
+These describe in-flight or recently-shipped work. Each pairs with an implementation plan and a runbook in `.claude/runs/`.
+
+| Spec | Status |
+|---|---|
+| [`docs/superpowers/specs/2026-05-06-drug-bioactive-bridge-design.md`](superpowers/specs/2026-05-06-drug-bioactive-bridge-design.md) | Phase 1 — landed via PR #19; ADR 0007; runbook at `.claude/runs/20260506-013000-drug-bioactive-bridge/` |
+| [`docs/KG_COMPLETENESS_AUDIT.md`](KG_COMPLETENESS_AUDIT.md) | KG audit (this PR) — identifies 5 concrete completeness gaps + remediation specs |
+
+PRD/plan/report/review documents from earlier phases live in `.claude/PRPs/{prds,plans,reports,reviews}/`. The legacy plans under `.claude/PRPs/plans/completed/` are kept for archaeology but should not be the primary reference for current architecture.
+
+---
+
+## Data engineers / ingest pipelines
+
+| File | One-line description |
+|---|---|
+| [`shrine-diet-bioactivity/Makefile`](../shrine-diet-bioactivity/Makefile) | Canonical entrypoints: `make download`, `make build`, `make migrate`, `make food-bridge`, `make build-identity`, `make build-bioactivity`, `make lightrag-ingest-*` |
+| [`docs/data-audit-results.md`](data-audit-results.md) | OpenNutrition coverage stats (calories 95.5%, protein 74.7%, etc.) — informs `data_completeness` flagging |
+| [`docs/kg-coverage-audit.md`](kg-coverage-audit.md) | HDI-Safe-50 vs public references coverage audit |
+| [`docs/KG_COMPLETENESS_AUDIT.md`](KG_COMPLETENESS_AUDIT.md) | This audit — entity-type counts, gap analysis vs use cases A/D, remediation specs |
+
+---
+
+## Researchers, paper, evaluation
+
+| File | One-line description |
+|---|---|
+| [`research-journal/README.md`](../research-journal/README.md) | Top of the research journal — design, handoffs, primary work |
+| [`research-journal/DESIGN.md`](../research-journal/DESIGN.md) | Initial program spec |
+| [`research-journal/DESIGN-PIVOT-2026-04-22.md`](../research-journal/DESIGN-PIVOT-2026-04-22.md) | Pivot rationale (clinical research team as primary impl) |
+| [`research-journal/HANDOFF-research-via-mcp.md`](../research-journal/HANDOFF-research-via-mcp.md) | How researchers use the staged MCP gateway |
+| [`research-journal/HANDOFF-blockers-to-engineering.md`](../research-journal/HANDOFF-blockers-to-engineering.md) | Open blockers needing engineering attention |
+| [`research-journal/primary/`](../research-journal/primary/) | Paper drafts (v1) — figures, tables, references |
+| [`docs/TESTING.md`](TESTING.md) | Testing strategy: unit (vitest, pytest), integration, E2E patterns |
+
+---
+
+## Tenant / clinical layer
+
+| File | One-line description |
+|---|---|
+| [`shrine-diet-bioactivity/docs/clinical-integration-notes.md`](../shrine-diet-bioactivity/docs/clinical-integration-notes.md) | Why clinical/culinary reasoning lives in the agent layer, not the MCP surface |
+| [`AGENT.md`](../AGENT.md) | Agent system overview (panel roles, triage, kg_query tool) |
+
+---
+
+## Operations / deployment
+
+| File | One-line description |
+|---|---|
+| [`mcp/README.md`](../mcp/README.md) | kg-mcp gateway deploy: Railway URL, auth setup, healthcheck |
+| [`research-journal/HANDOFF-railway-deploy.md`](../research-journal/HANDOFF-railway-deploy.md) | Railway deployment runbook for the gateway |
+| [`docs/graphiti-neo4j-guide.md`](graphiti-neo4j-guide.md) | _Legacy_ — Graphiti PoC notes (superseded by LightRAG; kept for context only) |
+
+---
+
+## Conventions
+
+- **One canonical doc per topic.** If you find duplicate coverage, consolidate and link.
+- **Cross-reference using relative paths** so renames are easier to track.
+- **ADRs are append-only.** Reverse a decision by writing a new ADR; never edit a closed one.
+- **Specs live under `docs/superpowers/specs/`** and follow `YYYY-MM-DD-<topic>-design.md` naming.
+- **Runbooks live under `.claude/runs/<run-id>/`** when they accompany a dispatch-pvp execution.
+- **Stale references** are a bug. If a doc points at a moved/deleted file, fix the link or remove the reference.
+
+---
+
+## Known gaps in this index
+
+- ADRs 0002–0006 do not exist; the numbering jumps. Either re-number or add stub ADRs explaining what wasn't captured.
+- `.claude/PRPs/plans/` has both active and completed plans, but the in-tree completed/ subdir is a partial archive — some "completed" plans live in the parent.
+- No top-level `CHANGELOG.md` exists; release-level changes are tracked only via git tags + paper drafts.

--- a/docs/KG_COMPLETENESS_AUDIT.md
+++ b/docs/KG_COMPLETENESS_AUDIT.md
@@ -1,0 +1,224 @@
+# KG Completeness & Utility Audit — 2026-05-07
+
+> Quantitative audit of the unified diet KG against the project's two priority use cases:
+>
+> - **A. Symptom → food.** Given a symptom, surface foods/herbs whose bioactives have evidence-graded drug-target activity.
+> - **D. Diet → predicted physiological effects.** Given a recorded diet, aggregate bioactive compound exposure → target modulation → predicted pathway/disease effects.
+>
+> Snapshot taken from `data_local/herbal_botanicals.db` (5.5 GB, 20 tables). Numbers reflect state on 2026-05-07 _before_ Phase 1 ChEMBL ingest runs.
+
+---
+
+## 1. Entity-level snapshot
+
+| Entity / table | Rows | Use-case relevance |
+|---|---:|---|
+| `herbs` (Duke) | 2,376 | A: backbone for symptom→herb mapping |
+| `herb2_herbs` (HERB 2.0) | 7,263 | A: 3× Duke coverage but **siloed** — no cross-resolution to `herbs` |
+| `compounds` | 94,512 | A, D, C: backbone — **0% have SMILES, 0% have populated PubChem CID** (see ADR 0007) |
+| `targets` | 4,355 | A, D: backbone — UniProt-typed, druggability annotated |
+| `symptoms` | **47** | A: hand-curated, intentionally narrow |
+| `symmap_modern_symptoms` | 1,148 | A: rich UMLS/MeSH/ICD-10/HPO IDs — **not joined to `symptoms`** |
+| `symmap_tcm_symptoms` | 2,285 | A: TCM coverage — **not joined to `symptoms`** |
+| `compound_foods` | 4,149,541 | D: dense food→compound graph |
+| `herb_compounds` | 99,280 | A: dense herb→compound graph |
+| `compound_targets` | 7,053 | A, D: target binding — **only 1,232 distinct compounds** |
+| `target_diseases` | 795,434 | A: target→disease — 2,976 distinct diseases |
+| `herb_symptoms` | 41,823 | A: 44/47 symptoms have herb mappings |
+| `herb2_herb_disease` | 1,797,785 | A: huge HERB 2.0 evidence — **siloed** by `herb2_herbs` |
+| `chemical_diseases` (CTD) | **0** | **GAP** — table exists, never populated |
+| `chemical_phenotypes` (CTD) | **0** | **GAP** — table exists, never populated |
+| `food_nutrition_bridge` | 647 | D: FooDB↔OpenNutrition bridge (small but high-value) |
+
+---
+
+## 2. Use-case fit analysis
+
+### Use case A — Symptom → food
+
+**Today's path** (string matching at query time, no materialized map):
+
+```
+Symptom (1 of 47)
+   → "name LIKE %X%" against target_diseases.disease_name
+       → target_diseases (≈2,976 diseases, 795K rows)
+           → targets (4,355)
+               → compound_targets (7,053 edges)
+                   → compounds (1,232 distinct with target binding)
+                       → compound_foods (food anchors)
+```
+
+**Empirical match coverage** (sample of 15 symptoms vs `target_diseases.disease_name`):
+
+| Symptom | String matches in `target_diseases` |
+|---|---:|
+| Cancer | 72,265 |
+| Pain | 12,480 |
+| Arthritis | 10,614 |
+| Diabetes | 9,286 |
+| Hypertension | 5,128 |
+| Asthma | 4,336 |
+| Bacterial infection | 3,740 |
+| Eczema | 3,461 |
+| Inflammation | 2,885 |
+| Fungal infection | 2,787 |
+| Heart disease | 2,766 |
+| Insomnia | 2,580 |
+| Obesity | 2,334 |
+| Fever | 2,265 |
+| Viral infection | 2,003 |
+
+**Verdict for A:** strong qualitative coverage. Strong **quantitative** weakness: matches are by free-text similarity, not by ontology join. Same disease may match multiple symptoms (Cancer matches "Cancer", "cancer", "carcinoma", "neoplasm", etc.) without confidence scoring or deduplication. `SymMap` has the formal MeSH/UMLS/ICD-10-CM crosswalk but it's not wired into the materialized graph.
+
+### Use case D — Diet → predicted physiological effects
+
+**The leverage molecules** are compounds in BOTH `compound_foods` AND `compound_targets`:
+
+| Set | Distinct compounds |
+|---|---:|
+| In `compound_foods` (food sources) | 61,174 |
+| In `compound_targets` (target binding) | 1,232 |
+| **Intersection (food ∩ target)** | **565** |
+
+**Verdict for D:** today, only 565 compounds power any food→target prediction. Phase 1's ChEMBL bridge (PR #19) will multiply this — once compound-identity resolution is run, compounds with InChIKey cross-refs gain measured ChEMBL bioactivity even if they had no `compound_targets` row. Conservative estimate: 5,000–10,000 compounds gain target evidence post-Phase 1.
+
+---
+
+## 3. Concrete completeness gaps
+
+Sorted by use-case impact × ease of remediation.
+
+### Gap 1 — `chemical_diseases` table is empty (CRITICAL — silent ingestion failure)
+
+- **Severity:** HIGH for use case A; the architecture diagram (`docs/unified-diet-kg-architecture.md`) advertises 17.7K chemicals × 3.8M chem-disease pairs from CTD, but the live DB has 0.
+- **Likely root cause:** the CTD `load-ctd.ts` script either never ran or failed silently during ingest.
+- **Remediation:** see [§4.1](#41-spec-load-ctd-chemicaldiseases). Concrete TDD spec below.
+
+### Gap 2 — Symptom → Disease map is implicit (HIGH — hurts A query quality)
+
+- **Severity:** HIGH for use case A; today every symptom→evidence query reduces to string-LIKE on `target_diseases.disease_name`. SymMap has the MeSH/UMLS/ICD-10/HPO crosswalk; ground-truth our 47 symptoms against SymMap modern symptoms once and freeze the resolution as a `symptom_disease_map` table.
+- **Remediation:** see [§4.2](#42-spec-materialized-symptom-disease-map). Concrete TDD spec below — has a RED test scaffolded in this PR.
+
+### Gap 3 — HERB 2.0 herbs are siloed (MEDIUM — A coverage gap)
+
+- **Severity:** MEDIUM for use case A; `herb2_herbs` (7,263 rows, with English / Chinese / Pinyin / Latin names) is unreachable from `herb_symptoms` and `herb_compounds`. The 1.8M `herb2_herb_disease` edges are rich but cannot join through to compounds or food sources.
+- **Remediation:** add a `herb_resolution_map(duke_id, herb2_id, name_match_type, name_match_score)` table built by joining `herbs.scientific_name` ↔ `herb2_herbs.latin` (exact match, fall back to Duke alternate_names). Once this lands, `herb2_herb_disease` becomes a transitively-queryable evidence layer for our 2,376 Duke herbs.
+- **Spec status:** identified, not yet drafted.
+
+### Gap 4 — Phase 1 compound-identity coverage is unknown (MEDIUM — D quality gate)
+
+- **Severity:** MEDIUM for use case D; Phase 1 (PR #19) will resolve InChIKeys for ~25K active compounds via PubChem. We do not yet know what fraction of those names PubChem can actually resolve given their unusual format (e.g. `(+)-1-HYDROXYPINORESINOL-4.4'-GLUCOPYRANOSIDE`). If <50% resolve, the bioactivity evidence layer is correspondingly thin.
+- **Remediation:** run `make build-identity` post-merge of #19, capture the coverage report (already emitted by the build script's WARNING line). If <50%, a name-normalization Phase 1.5 (strip stereochemistry markers, prefix punctuation) becomes a TDD-able spec.
+- **Spec status:** measurement pending PR #19 merge + first ingest run.
+
+### Gap 5 — Symptoms are tiny (47 hand-curated) (LOW — works as designed but limits A breadth)
+
+- **Severity:** LOW for use case A in the near term. The 47 symptoms cover the spec's clinical scope. SymMap's 1,148 modern + 2,285 TCM symptoms could expand `symptoms` if a use case demands more granular indexing — but adding them adds maintenance load without a clear consumer today.
+- **Remediation:** parked. Revisit if A queries surface symptom mismatches that the 47-row vocabulary cannot represent.
+
+---
+
+## 4. TDD specs for top remediation work
+
+### 4.1 SPEC: load CTD `chemical_diseases`
+
+**Single failing test that captures the requirement** — landed in this PR as a **RED** test (xfail-marked until implementation lands).
+
+```python
+# shrine-diet-bioactivity/lightrag/tests/test_ctd_coverage.py
+def test_chemical_diseases_has_meaningful_coverage(db_conn):
+    """CTD chem→disease map should have ≥10K rows after ingest.
+
+    Phase 2 spec: implement scripts/load-ctd.ts (or .py) to ingest
+    CTD CSV.gz → chemical_diseases. Architecture promises ~3.8M rows;
+    we floor at 10K so the test passes as soon as ingest is wired up
+    (with room to ratchet up after).
+    """
+    n = db_conn.execute("SELECT COUNT(*) FROM chemical_diseases").fetchone()[0]
+    assert n >= 10_000, (
+        f"chemical_diseases has {n} rows; CTD ingest likely never ran "
+        "(see docs/KG_COMPLETENESS_AUDIT.md §3 Gap 1)"
+    )
+```
+
+Implementation work (separate spec/PR): port the existing `scripts/load-ctd.ts` (or rebuild it from the CTD CSV.gz under `data/`), wire it into `make migrate` after Duke + FooDB load.
+
+### 4.2 SPEC: materialized symptom→disease map
+
+This is the **highest-leverage gap for use case A**, and the most-easily TDD'd. Scaffolding the failing test in this PR.
+
+**Schema:**
+
+```sql
+CREATE TABLE symptom_disease_map (
+  symptom_id     INTEGER NOT NULL,
+  disease_name   TEXT NOT NULL,
+  source         TEXT NOT NULL,        -- 'symmap_modern' | 'symmap_tcm' | 'string_match'
+  symmap_id      TEXT,                  -- formal SymMap ID when available
+  mesh_id        TEXT,                  -- MeSH crosswalk
+  umls_id        TEXT,                  -- UMLS crosswalk
+  icd10cm_id     TEXT,
+  match_score    REAL NOT NULL,         -- 0.0–1.0; higher = better
+  PRIMARY KEY (symptom_id, disease_name, source),
+  FOREIGN KEY (symptom_id) REFERENCES symptoms(id)
+);
+```
+
+**Build pipeline:**
+
+1. For each row in `symptoms`, fuzzy-match `symptoms.name` against `symmap_modern_symptoms.name` (exact → token-overlap → substring); pull the formal IDs (`mesh_id`, `umls_id`, `icd10cm_id`).
+2. Repeat against `symmap_tcm_symptoms`.
+3. For symptoms with no SymMap hit, fall back to `string_match` against distinct `target_diseases.disease_name` with a confidence score derived from string similarity.
+4. Persist with provenance.
+
+**Acceptance criteria** (failing tests in `lightrag/tests/test_symptom_disease_map.py`, scaffolded RED in this PR):
+
+- After `make build-symptom-disease-map`, ≥40 of 47 symptoms have ≥1 row.
+- Inflammation, Diabetes, Hypertension all map to ≥1 SymMap row with a non-NULL MeSH ID.
+- `match_score` is in [0.0, 1.0] for every row.
+- The build is idempotent (re-running doesn't duplicate rows).
+
+### 4.3 SPEC: HERB 2.0 ↔ Duke resolution
+
+Outline only (no failing test in this PR, since this gap depends on a herb-name normalization library):
+
+- New table `herb_resolution_map`
+- Match strategies: Latin name exact, alternate-names exact, common-name token overlap
+- Test: ≥1,500 of 2,376 Duke herbs resolve to a HERB 2.0 row
+- Test: every resolution row has `match_type ∈ {latin_exact, alt_name_exact, token_overlap}` and a confidence score
+
+---
+
+## 5. Doneness criteria for KG utility (per use case)
+
+Use these to drive future Phase 2/3 specs and to gate releases.
+
+### Use case A — Symptom → food
+
+- [ ] Every one of the 47 symptoms has ≥1 mapping in `symptom_disease_map` with confidence ≥0.5.
+- [ ] CTD `chemical_diseases` populated with ≥1M rows (architecture target).
+- [ ] HERB 2.0 herbs resolved to Duke herbs for ≥75% of compound-bearing herbs.
+- [ ] For each symptom, top-10 ranked food results have at least one ChEMBL bioactivity citation in the response. (Requires Phase 1 ChEMBL ingest run.)
+
+### Use case D — Diet → predicted physiological effects
+
+- [ ] ≥5,000 compounds with measured ChEMBL bioactivity (Phase 1 ChEMBL ingest run; PR #19 enables this).
+- [ ] ≥1,500 compounds at the food ∩ target intersection (vs current 565). Requires Phase 1 + name normalization.
+- [ ] Pathway-level rollup available — requires Phase 2 KEGG overlay.
+- [ ] Aggregate scoring function published in a spec, with regression test.
+
+### Use case C — Compound mechanism dossier
+
+- [ ] For every compound in `compound_identity` with `unichem_src_count ≥ 2`, the dossier surfaces structure (SMILES + InChI), drug-likeness signal, target list with evidence, food sources, and KEGG pathway IDs (when available).
+
+---
+
+## 6. Suggested next dispatch-pvp run
+
+Highest-ROI follow-up: implement [§4.2 — symptom→disease map](#42-spec-materialized-symptom-disease-map). Concrete because:
+- Schema is fixed in this audit.
+- Failing test scaffolded in this PR (RED state).
+- Build pipeline is ~150 LOC of Python over existing tables (no new data downloads).
+- Directly improves use case A query quality, which is the primary user-facing surface.
+
+Suggested branch / PR title: `phase1.5/symptom-disease-map` → `feat(kg): materialized symptom→disease map (use case A)`.

--- a/shrine-diet-bioactivity/lightrag/tests/test_kg_completeness_gates.py
+++ b/shrine-diet-bioactivity/lightrag/tests/test_kg_completeness_gates.py
@@ -1,0 +1,166 @@
+"""KG completeness gates — RED tests pinning the use-case A/D doneness criteria.
+
+These tests are the regression surface for the gaps catalogued in
+`docs/KG_COMPLETENESS_AUDIT.md`. Every test here is intentionally RED today;
+each is marked ``xfail`` with a strict reason so:
+
+  - Coverage of "what's broken" is visible in the test runner output.
+  - When a gap is closed by a follow-up PR, the corresponding xfail test
+    flips GREEN and pytest reports XPASS — surfaced as a hard failure
+    (because of ``strict=True``) so the owner remembers to flip ``xfail``
+    off once the work has landed.
+
+This is TDD applied to the audit: the test goes in BEFORE the
+implementation. When you implement, you delete the ``@pytest.mark.xfail``
+line and watch it pass.
+
+Live-DB gating: every test skips cleanly if the 5.5GB
+``data_local/herbal_botanicals.db`` is absent (CI doesn't ship it).
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+DB_PATH = (
+    Path(__file__).parent.parent.parent / "data_local" / "herbal_botanicals.db"
+)
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+@pytest.fixture(scope="module")
+def db_conn() -> sqlite3.Connection:
+    if not DB_PATH.exists():
+        pytest.skip(f"Live DB not present at {DB_PATH}; skipping completeness gates.")
+    return sqlite3.connect(str(DB_PATH))
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — CTD chemical_diseases empty (audit §3 Gap 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Audit §3 Gap 1: chemical_diseases table is empty in live DB despite "
+        "the architecture promising ~3.8M CTD rows. Implementation tracked at "
+        "audit §4.1 — load-ctd ingest script. Flip xfail off once implemented."
+    ),
+)
+def test_chemical_diseases_has_meaningful_coverage(db_conn: sqlite3.Connection) -> None:
+    """CTD chem→disease map should have ≥10K rows after ingest."""
+    assert _table_exists(db_conn, "chemical_diseases")
+    n = db_conn.execute("SELECT COUNT(*) FROM chemical_diseases").fetchone()[0]
+    assert n >= 10_000, (
+        f"chemical_diseases has {n} rows; CTD ingest never ran. "
+        "See docs/KG_COMPLETENESS_AUDIT.md §3 Gap 1 + §4.1."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 — symptom→disease map missing (audit §3 Gap 2 + §4.2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Audit §3 Gap 2: symptom_disease_map table not yet built. "
+        "Highest-leverage gap for use case A. Implementation spec at §4.2; "
+        "schema + build pipeline + acceptance criteria defined. "
+        "Flip xfail off once make build-symptom-disease-map exists."
+    ),
+)
+def test_symptom_disease_map_table_exists(db_conn: sqlite3.Connection) -> None:
+    assert _table_exists(db_conn, "symptom_disease_map"), (
+        "symptom_disease_map table not present. See audit §4.2 for schema."
+    )
+
+
+@pytest.mark.xfail(strict=True, reason="depends on symptom_disease_map (audit §4.2)")
+def test_symptom_disease_map_covers_most_symptoms(db_conn: sqlite3.Connection) -> None:
+    """≥40 of the 47 hand-curated symptoms must have ≥1 disease mapping."""
+    n_symptoms = db_conn.execute("SELECT COUNT(*) FROM symptoms").fetchone()[0]
+    assert n_symptoms >= 47  # sanity floor
+
+    n_mapped = db_conn.execute(
+        "SELECT COUNT(DISTINCT symptom_id) FROM symptom_disease_map"
+    ).fetchone()[0]
+    assert n_mapped >= 40, (
+        f"Only {n_mapped}/{n_symptoms} symptoms have disease mappings. "
+        "Audit §4.2 requires ≥40."
+    )
+
+
+@pytest.mark.xfail(strict=True, reason="depends on symptom_disease_map (audit §4.2)")
+def test_inflammation_diabetes_hypertension_have_mesh_ids(
+    db_conn: sqlite3.Connection,
+) -> None:
+    """Three high-volume symptoms must resolve to a SymMap row with a MeSH ID.
+
+    These three are picked because they have the richest target_diseases
+    string-match coverage (Inflammation 2,885; Diabetes 9,286; Hypertension
+    5,128) — if even these don't map cleanly, the build pipeline is broken.
+    """
+    rows = db_conn.execute(
+        """
+        SELECT s.name, COUNT(*) AS n_with_mesh
+        FROM symptoms s
+        JOIN symptom_disease_map sdm ON sdm.symptom_id = s.id
+        WHERE s.name IN ('Inflammation', 'Diabetes', 'Hypertension')
+          AND sdm.mesh_id IS NOT NULL
+        GROUP BY s.name
+        """
+    ).fetchall()
+    names_with_mesh = {r[0] for r in rows}
+    expected = {"Inflammation", "Diabetes", "Hypertension"}
+    missing = expected - names_with_mesh
+    assert not missing, (
+        f"These symptoms have no MeSH-anchored disease mapping: {sorted(missing)}. "
+        "Audit §4.2 requires all three to resolve."
+    )
+
+
+@pytest.mark.xfail(strict=True, reason="depends on symptom_disease_map (audit §4.2)")
+def test_match_score_in_valid_range(db_conn: sqlite3.Connection) -> None:
+    bad = db_conn.execute(
+        "SELECT COUNT(*) FROM symptom_disease_map "
+        "WHERE match_score < 0.0 OR match_score > 1.0"
+    ).fetchone()[0]
+    assert bad == 0, f"{bad} rows have match_score outside [0,1]"
+
+
+# ---------------------------------------------------------------------------
+# Gap 3 — HERB 2.0 ↔ Duke resolution (audit §3 Gap 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Audit §3 Gap 3: herb_resolution_map table missing. HERB 2.0 herbs "
+        "are siloed from Duke herb_compounds. Implementation spec at §4.3; "
+        "depends on a herb-name normalization library."
+    ),
+)
+def test_herb_resolution_covers_majority_of_duke_herbs(
+    db_conn: sqlite3.Connection,
+) -> None:
+    n_duke = db_conn.execute("SELECT COUNT(*) FROM herbs").fetchone()[0]
+    n_resolved = db_conn.execute(
+        "SELECT COUNT(DISTINCT duke_id) FROM herb_resolution_map"
+    ).fetchone()[0]
+    # Audit §4.3 target: ≥75% (~1,782 of 2,376).
+    assert n_resolved >= int(0.75 * n_duke), (
+        f"{n_resolved}/{n_duke} Duke herbs resolved to HERB 2.0 (need ≥75%)."
+    )


### PR DESCRIPTION
## Summary

Three deliverables, all docs/test only (no production-code changes):

1. **`docs/INDEX.md`** — single source of navigation for the project, grouped by audience. Replaces the ad-hoc collection of READMEs scattered across top-level / `docs/` / `shrine-diet-bioactivity/docs/` / `research-journal/`. README.md links to it prominently.

2. **`docs/KG_COMPLETENESS_AUDIT.md`** — quantitative audit of the live KG against the two priority use cases (Symptom→food, Diet→effects). Five concrete gaps ranked by impact × ease, with TDD specs for the top three.

3. **`lightrag/tests/test_kg_completeness_gates.py`** — 6 RED tests (`xfail` strict) pinning the highest-leverage gaps from the audit. They go XPASS-strict (= hard test failure) when the implementations land, forcing owners to flip the xfail markers off.

## Notable audit findings

- **`chemical_diseases` and `chemical_phenotypes` are empty (0 rows).** The architecture diagram promises 17.7K chemicals × 3.8M chem-disease pairs from CTD; the live DB has none. Silent ingestion failure.
- **Symptom→Disease bridge is implicit.** Today every "find foods for symptom X" query reduces to `LIKE '%X%'` against `target_diseases.disease_name`. SymMap has the formal MeSH/UMLS/ICD-10/HPO crosswalk, but it's not joined to our 47 hand-curated symptoms.
- **HERB 2.0 silo:** 7,263 herbs and 1.8M herb-disease edges are unreachable from `herb_compounds` because there's no resolution map between Duke `herbs.scientific_name` and `herb2_herbs.latin`.
- **D leverage point:** 565 compounds at the food ∩ target intersection today. Phase 1's ChEMBL bridge (PR #19) should multiply this 5–10x.
- **Use case A coverage is solid qualitatively** (Cancer 72K matches, Diabetes 9K, etc. via string match) but lacks ranking and confidence scoring.

## Suggested next dispatch-pvp run

Per audit §6, the highest-ROI follow-up is **§4.2 — materialized symptom→disease map**. Schema fixed, failing tests scaffolded in this PR, build pipeline ~150 LOC over existing tables, no new data downloads, directly improves use case A query quality.

## Test plan

- [x] All 6 audit-gate tests are RED (xfail) when run against the live `data_local/herbal_botanicals.db` — verified locally.
- [x] All 6 tests skip cleanly in CI (no live DB present).
- [x] No production code changed — strictly docs + tests.
- [x] Targeting `test` per the project promotion policy.

## Out of scope (separate PRs)

- Implementing CTD ingest (audit §4.1)
- Implementing the symptom→disease map build pipeline (audit §4.2)
- HERB 2.0 ↔ Duke herb resolution (audit §4.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)