### PR TITLE
feat(kg): materialized symptom→disease map (audit §4.2 / Gap 2)

### DIFF
--- a/docs/KG_COMPLETENESS_AUDIT.md
+++ b/docs/KG_COMPLETENESS_AUDIT.md
@@ -94,10 +94,15 @@ Sorted by use-case impact × ease of remediation.
 - **Likely root cause:** the CTD `load-ctd.ts` script either never ran or failed silently during ingest.
 - **Remediation:** see [§4.1](#41-spec-load-ctd-chemicaldiseases). Concrete TDD spec below.
 
-### Gap 2 — Symptom → Disease map is implicit (HIGH — hurts A query quality)
+### Gap 2 — ~~Symptom → Disease map is implicit~~ ✅ **RESOLVED 2026-05-07**
 
-- **Severity:** HIGH for use case A; today every symptom→evidence query reduces to string-LIKE on `target_diseases.disease_name`. SymMap has the MeSH/UMLS/ICD-10/HPO crosswalk; ground-truth our 47 symptoms against SymMap modern symptoms once and freeze the resolution as a `symptom_disease_map` table.
-- **Remediation:** see [§4.2](#42-spec-materialized-symptom-disease-map). Concrete TDD spec below — has a RED test scaffolded in this PR.
+- **Status:** Resolved by `phase2/symptom-disease-map`. 40/47 symptoms mapped (audit acceptance ≥40), 33 with MeSH IDs, 1 fallback-only. All four audit-gate tests in `test_kg_completeness_gates.py` are now GREEN.
+- **What landed:**
+  - `symptom_disease_map` table populated by 4-tier matcher (exact / Jaccard / substring / content-token / target_diseases fallback) with MeSH/UMLS/ICD-10 cross-refs from SymMap.
+  - LightRAG `MAPS_TO_DISEASE` relationship type so the bridge surfaces in Neo4j queries.
+  - 13 unit tests + 5 audit-gate tests covering each tier, the stopword filter, and the mesh-id tie-breaker.
+- **Original spec:** see [§4.2](#42-spec-materialized-symptom-disease-map).
+- **Remaining 7 unmapped symptoms** (Allergies, Bile insufficiency, Blood clotting, Fluid retention, Low immunity, Low milk supply, Neurodegeneration, Poor circulation) are clinical-concept terms with no literal hit in either source; flagged as Phase 2.5 hand-curation candidates.
 
 ### Gap 3 — HERB 2.0 herbs are siloed (MEDIUM — A coverage gap)
 

--- a/shrine-diet-bioactivity/Makefile
+++ b/shrine-diet-bioactivity/Makefile
@@ -380,3 +380,10 @@ bridge-test:
 	       lightrag/tests/test_ingest_bioactivity.py \
 	       --cov=identity_bridge --cov=chembl_extractor \
 	       --cov-report=term-missing -v
+
+# ─── Phase 2 symptom→disease map ────────────────────────────
+.PHONY: build-symptom-disease-map
+
+build-symptom-disease-map:
+	python scripts/build_symptom_disease_map.py \
+		--db data_local/herbal_botanicals.db

--- a/shrine-diet-bioactivity/lightrag/entity_schema.py
+++ b/shrine-diet-bioactivity/lightrag/entity_schema.py
@@ -208,6 +208,21 @@ RELATIONSHIP_TYPES = {
             "ORDER BY be.id"
         ),
     },
+    # -- Phase 2 symptom→disease materialized map (audit §4.2) --
+    "MAPS_TO_DISEASE": {
+        "source_table": "symptom_disease_map",
+        "src_type": "Symptom",
+        "tgt_type": "Disease",
+        "query": (
+            "SELECT s.name AS src_name, sdm.disease_name AS tgt_name, "
+            "sdm.source AS source, sdm.mesh_id AS mesh_id, "
+            "sdm.umls_id AS umls_id, sdm.icd10cm_id AS icd10cm_id, "
+            "sdm.match_score AS match_score "
+            "FROM symptom_disease_map sdm "
+            "JOIN symptoms s ON s.id = sdm.symptom_id "
+            "ORDER BY s.id, sdm.match_score DESC"
+        ),
+    },
     # -- Tenant relationship types (clinical practice layer) --
     # These have no SQLite source — ingested via tenant API (Phase 4).
     "INCLUDES": {
@@ -649,6 +664,20 @@ def describe_relationship(rel_type: str, row: dict[str, Any]) -> tuple[str, str]
         if extras:
             desc += " (" + ", ".join(extras) + ")"
         return desc, "evidence target measurement assay confidence"
+
+    if rel_type == "MAPS_TO_DISEASE":
+        # Phase 2 — materialized symptom→disease bridge (audit §4.2).
+        source = row.get("source", "string_match")
+        mesh = row.get("mesh_id")
+        score = row.get("match_score")
+        desc = f"{src} maps to disease {tgt}"
+        details: list[str] = [f"via {source}"]
+        if mesh:
+            details.append(f"MeSH {mesh}")
+        if score is not None:
+            details.append(f"score {score}")
+        desc += " (" + ", ".join(details) + ")"
+        return desc, "symptom disease ontology mesh umls icd"
 
     # -- Tenant relationship types (clinical practice layer) --
 

--- a/shrine-diet-bioactivity/lightrag/symptom_matcher.py
+++ b/shrine-diet-bioactivity/lightrag/symptom_matcher.py
@@ -1,0 +1,258 @@
+"""Symptom → disease/SymMap matcher (audit §4.2 spec).
+
+Pure logic — no DB. Callers feed lists of dicts that mirror the live
+SymMap table shape; the matcher returns a single best ``MatchResult`` per
+query symptom (or ``None`` if nothing matches at any tier).
+
+Four-tier strategy, applied in order (first hit wins):
+
+  Tier 1 — case-insensitive exact match against ``symmap_modern.name``
+           or ``symmap_tcm.name_en``. Score 1.0. Carries MeSH/UMLS/ICD-10/HPO.
+
+  Tier 2 — token-Jaccard ≥ 0.5 against the same tables. Score = jaccard.
+           Tied scores broken by tier-1-source preference (modern > tcm).
+
+  Tier 3 — substring containment: query contained in SymMap name OR
+           SymMap name contained in query. Score = 0.5–0.8 based on
+           length ratio (longer overlap = higher score). When several
+           rows match, prefer the one with the highest token overlap
+           with the query (so "Heart Disease" picks "Acute Heart Disease"
+           over "Acute Disease" — both substring-match but the former
+           shares more meaningful tokens).
+
+  Tier 4 — fallback to ``target_diseases.disease_name`` substring search.
+           No formal IDs. Score 0.3 — clearly weaker than SymMap matches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    """Single best disease/concept mapping for a symptom query."""
+
+    disease_name: str  # canonical name from SymMap or target_diseases
+    source: str  # 'symmap_modern' | 'symmap_tcm' | 'string_match'
+    symmap_id: Optional[str]
+    mesh_id: Optional[str]
+    umls_id: Optional[str]
+    icd10cm_id: Optional[str]
+    match_score: float  # in [0.0, 1.0]
+
+
+def _norm(s: str) -> str:
+    return (s or "").strip().lower()
+
+
+# Tokens that carry too little signal to anchor a match on their own.
+# E.g. "low libido" → head token 'low' is generic; want to match on 'libido'.
+_STOPWORDS = frozenset(
+    {
+        "low",
+        "high",
+        "poor",
+        "good",
+        "bad",
+        "the",
+        "of",
+        "a",
+        "an",
+        "and",
+        "or",
+        "with",
+        "without",
+    }
+)
+
+
+def _tokens(s: str) -> set[str]:
+    return {t for t in _norm(s).replace("-", " ").split() if t}
+
+
+def _content_tokens(s: str) -> set[str]:
+    """Tokens minus stopwords — the semantically informative slice."""
+    return _tokens(s) - _STOPWORDS
+
+
+def token_jaccard(a: str, b: str) -> float:
+    """Jaccard similarity over normalized whitespace-split tokens."""
+    ta, tb = _tokens(a), _tokens(b)
+    if not ta or not tb:
+        return 0.0
+    inter = len(ta & tb)
+    union = len(ta | tb)
+    return inter / union if union else 0.0
+
+
+def _modern_to_match(row: dict, score: float, source: str) -> MatchResult:
+    return MatchResult(
+        disease_name=row.get("name") or "",
+        source=source,
+        symmap_id=row.get("symmap_id"),
+        mesh_id=row.get("mesh_id"),
+        umls_id=row.get("umls_id"),
+        icd10cm_id=row.get("icd10cm_id"),
+        match_score=score,
+    )
+
+
+def _tcm_to_match(row: dict, score: float) -> MatchResult:
+    # TCM rows lack MeSH; carry symmap_id + UMLS where present.
+    return MatchResult(
+        disease_name=row.get("name_en") or "",
+        source="symmap_tcm",
+        symmap_id=row.get("symmap_id"),
+        mesh_id=None,
+        umls_id=row.get("umls_id"),
+        icd10cm_id=None,
+        match_score=score,
+    )
+
+
+def _string_match_to_match(disease: str, score: float) -> MatchResult:
+    return MatchResult(
+        disease_name=disease,
+        source="string_match",
+        symmap_id=None,
+        mesh_id=None,
+        umls_id=None,
+        icd10cm_id=None,
+        match_score=score,
+    )
+
+
+def match_symptom(
+    symptom: str,
+    *,
+    modern: Iterable[dict],
+    tcm: Iterable[dict],
+    diseases: Iterable[str],
+    jaccard_threshold: float = 0.5,
+) -> Optional[MatchResult]:
+    """Return the best disease/concept mapping for ``symptom``, or None.
+
+    Tries four tiers in order; first non-None wins.
+    """
+    q = _norm(symptom)
+    if not q:
+        return None
+    q_tokens = _tokens(q)
+
+    modern_list = list(modern)
+    tcm_list = list(tcm)
+
+    # ---- Tier 1: case-insensitive exact ----
+    for row in modern_list:
+        if _norm(row.get("name", "")) == q:
+            return _modern_to_match(row, 1.0, "symmap_modern")
+    for row in tcm_list:
+        if _norm(row.get("name_en", "")) == q:
+            return _tcm_to_match(row, 1.0)
+
+    # ---- Tier 2: token Jaccard (≥ threshold) ----
+    # Tie-breaker (score, has_mesh_id) — when two rows have equal Jaccard,
+    # prefer the row whose mesh_id is non-NULL (downstream-joinable).
+    best_jaccard: tuple[tuple, dict, str] | None = None
+    for row in modern_list:
+        sc = token_jaccard(q, row.get("name", ""))
+        if sc >= jaccard_threshold:
+            has_mesh = 1 if row.get("mesh_id") else 0
+            sort_key = (sc, has_mesh)
+            if best_jaccard is None or sort_key > best_jaccard[0]:
+                best_jaccard = (sort_key, row, "symmap_modern")
+    for row in tcm_list:
+        sc = token_jaccard(q, row.get("name_en", ""))
+        if sc >= jaccard_threshold:
+            sort_key = (sc, 0)  # TCM has no mesh
+            if best_jaccard is None or sort_key > best_jaccard[0]:
+                best_jaccard = (sort_key, row, "symmap_tcm")
+    if best_jaccard is not None:
+        sort_key, row, source = best_jaccard
+        score = sort_key[0]
+        if source == "symmap_modern":
+            return _modern_to_match(row, score, source)
+        return _tcm_to_match(row, score)
+
+    # ---- Tier 3: substring containment ----
+    # Score = 0.5 + 0.3 * (token-overlap fraction). Pick the row with the
+    # most shared tokens to break ties. Range 0.5..0.8 — strictly less
+    # than 1.0 so callers can rank tier-1 matches above tier-3.
+    #
+    # Tie-breaker key: (score, shared_tokens, has_mesh_id). The has_mesh_id
+    # bit means that when multiple rows substring-match with identical token
+    # overlap (e.g. "Hypertension" matches both "Essential Hypertension"
+    # MeSH=C562386 AND "Rebound Hypertension" MeSH=NULL), we prefer the row
+    # with downstream-joinable formal IDs.
+    best_substring: tuple[tuple, dict, str] | None = None
+    for row in modern_list:
+        name = row.get("name", "")
+        n = _norm(name)
+        if not n:
+            continue
+        if q in n or n in q:
+            shared = len(q_tokens & _tokens(name))
+            denom = max(len(q_tokens), 1)
+            score = 0.5 + 0.3 * (shared / denom)
+            score = min(score, 0.8)
+            has_mesh = 1 if row.get("mesh_id") else 0
+            sort_key = (score, shared, has_mesh)
+            if best_substring is None or sort_key > best_substring[0]:
+                best_substring = (sort_key, row, "symmap_modern")
+    for row in tcm_list:
+        name = row.get("name_en", "")
+        n = _norm(name)
+        if not n:
+            continue
+        if q in n or n in q:
+            shared = len(q_tokens & _tokens(name))
+            denom = max(len(q_tokens), 1)
+            score = 0.5 + 0.3 * (shared / denom)
+            score = min(score, 0.8)
+            # TCM has no mesh_id, weight has_mesh=0.
+            sort_key = (score, shared, 0)
+            if best_substring is None or sort_key > best_substring[0]:
+                best_substring = (sort_key, row, "symmap_tcm")
+    if best_substring is not None:
+        sort_key, row, source = best_substring
+        score = sort_key[0]
+        if source == "symmap_modern":
+            return _modern_to_match(row, score, source)
+        return _tcm_to_match(row, score)
+
+    # ---- Tier 3.5: content-token match against SymMap ----
+    # When a symptom's head/content token (e.g. 'memory' from 'Memory decline',
+    # 'libido' from 'Low libido') appears in a SymMap name, that's a strong
+    # concept signal even if Jaccard is low. Score 0.4 — lower than substring
+    # but still anchored to formal MeSH/UMLS IDs.
+    q_content = _content_tokens(q)
+    if q_content:
+        best_token: tuple[int, dict, str] | None = None
+        for row in modern_list:
+            row_content = _content_tokens(row.get("name", ""))
+            shared = len(q_content & row_content)
+            if shared > 0 and (best_token is None or shared > best_token[0]):
+                best_token = (shared, row, "symmap_modern")
+        for row in tcm_list:
+            row_content = _content_tokens(row.get("name_en", ""))
+            shared = len(q_content & row_content)
+            if shared > 0 and (best_token is None or shared > best_token[0]):
+                best_token = (shared, row, "symmap_tcm")
+        if best_token is not None:
+            shared, row, source = best_token
+            score = 0.4
+            if source == "symmap_modern":
+                return _modern_to_match(row, score, source)
+            return _tcm_to_match(row, score)
+
+    # ---- Tier 4: fallback to target_diseases substring ----
+    for disease in diseases:
+        n = _norm(disease)
+        if not n:
+            continue
+        if q in n or n in q:
+            return _string_match_to_match(disease, 0.3)
+
+    return None

--- a/shrine-diet-bioactivity/lightrag/tests/test_kg_completeness_gates.py
+++ b/shrine-diet-bioactivity/lightrag/tests/test_kg_completeness_gates.py
@@ -17,6 +17,7 @@ line and watch it pass.
 Live-DB gating: every test skips cleanly if the 5.5GB
 ``data_local/herbal_botanicals.db`` is absent (CI doesn't ship it).
 """
+
 from __future__ import annotations
 
 import sqlite3
@@ -24,9 +25,7 @@ from pathlib import Path
 
 import pytest
 
-DB_PATH = (
-    Path(__file__).parent.parent.parent / "data_local" / "herbal_botanicals.db"
-)
+DB_PATH = Path(__file__).parent.parent.parent / "data_local" / "herbal_botanicals.db"
 
 
 def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
@@ -72,22 +71,13 @@ def test_chemical_diseases_has_meaningful_coverage(db_conn: sqlite3.Connection) 
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Audit §3 Gap 2: symptom_disease_map table not yet built. "
-        "Highest-leverage gap for use case A. Implementation spec at §4.2; "
-        "schema + build pipeline + acceptance criteria defined. "
-        "Flip xfail off once make build-symptom-disease-map exists."
-    ),
-)
 def test_symptom_disease_map_table_exists(db_conn: sqlite3.Connection) -> None:
+    """Schema landed by phase2/symptom-disease-map (audit §4.2)."""
     assert _table_exists(db_conn, "symptom_disease_map"), (
         "symptom_disease_map table not present. See audit §4.2 for schema."
     )
 
 
-@pytest.mark.xfail(strict=True, reason="depends on symptom_disease_map (audit §4.2)")
 def test_symptom_disease_map_covers_most_symptoms(db_conn: sqlite3.Connection) -> None:
     """≥40 of the 47 hand-curated symptoms must have ≥1 disease mapping."""
     n_symptoms = db_conn.execute("SELECT COUNT(*) FROM symptoms").fetchone()[0]
@@ -102,7 +92,6 @@ def test_symptom_disease_map_covers_most_symptoms(db_conn: sqlite3.Connection) -
     )
 
 
-@pytest.mark.xfail(strict=True, reason="depends on symptom_disease_map (audit §4.2)")
 def test_inflammation_diabetes_hypertension_have_mesh_ids(
     db_conn: sqlite3.Connection,
 ) -> None:
@@ -131,13 +120,39 @@ def test_inflammation_diabetes_hypertension_have_mesh_ids(
     )
 
 
-@pytest.mark.xfail(strict=True, reason="depends on symptom_disease_map (audit §4.2)")
 def test_match_score_in_valid_range(db_conn: sqlite3.Connection) -> None:
     bad = db_conn.execute(
         "SELECT COUNT(*) FROM symptom_disease_map "
         "WHERE match_score < 0.0 OR match_score > 1.0"
     ).fetchone()[0]
     assert bad == 0, f"{bad} rows have match_score outside [0,1]"
+
+
+def test_maps_to_disease_relationship_query_runs(db_conn: sqlite3.Connection) -> None:
+    """MAPS_TO_DISEASE in entity_schema must query the symptom_disease_map cleanly."""
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from entity_schema import RELATIONSHIP_TYPES, describe_relationship
+
+    assert "MAPS_TO_DISEASE" in RELATIONSHIP_TYPES
+    spec = RELATIONSHIP_TYPES["MAPS_TO_DISEASE"]
+    assert spec["src_type"] == "Symptom"
+    assert spec["tgt_type"] == "Disease"
+
+    # The query must execute against the populated map.
+    rows = list(db_conn.execute(spec["query"]))
+    assert len(rows) >= 40, (
+        f"Expected ≥40 MAPS_TO_DISEASE edges (one per mapped symptom); got {len(rows)}"
+    )
+
+    cols = [d[0] for d in db_conn.execute(spec["query"]).description]
+    sample = dict(zip(cols, rows[0]))
+    desc, kw = describe_relationship("MAPS_TO_DISEASE", sample)
+    assert sample["src_name"] in desc
+    assert sample["tgt_name"] in desc
+    assert "symptom" in kw and "disease" in kw
 
 
 # ---------------------------------------------------------------------------

--- a/shrine-diet-bioactivity/lightrag/tests/test_symptom_matcher.py
+++ b/shrine-diet-bioactivity/lightrag/tests/test_symptom_matcher.py
@@ -1,0 +1,292 @@
+"""Unit tests for the symptom→SymMap matcher.
+
+Pure logic tests — no DB. The matcher is fed lists of dictionaries that
+mirror the SymMap table shapes, so we can exhaustively cover the four-tier
+matching strategy (exact / token-overlap / substring / fallback) without
+needing the 5.5GB live DB.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make lightrag/ importable when pytest runs from the project root.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from symptom_matcher import (  # noqa: E402
+    MatchResult,
+    match_symptom,
+    token_jaccard,
+)
+
+
+# Fixture data — slimmed slices of the real SymMap shape.
+# Modern symptoms have name + mesh_id + umls_id + icd10cm_id + symmap_id.
+# TCM symptoms have name_en + symmap_id + umls_id (no MeSH).
+MODERN = [
+    {
+        "symmap_id": "SMMS0001",
+        "name": "Inflammation",
+        "mesh_id": "D007249",
+        "umls_id": "C0021368",
+        "icd10cm_id": None,
+    },
+    {
+        "symmap_id": "SMMS0002",
+        "name": "Diabetes Mellitus",
+        "mesh_id": "D003920",
+        "umls_id": "C0011849",
+        "icd10cm_id": "E11",
+    },
+    {
+        "symmap_id": "SMMS0003",
+        "name": "Essential Hypertension",
+        "mesh_id": "C562386",
+        "umls_id": "C0085580",
+        "icd10cm_id": "I10",
+    },
+    {
+        "symmap_id": "SMMS0004",
+        "name": "Bronchial Asthma",
+        "mesh_id": "D001249",
+        "umls_id": None,
+        "icd10cm_id": None,
+    },
+    {
+        "symmap_id": "SMMS0005",
+        "name": "Pain",
+        "mesh_id": "D010146",
+        "umls_id": "C0030193",
+        "icd10cm_id": None,
+    },
+    {
+        "symmap_id": "SMMS0006",
+        "name": "Acute Heart Disease",
+        "mesh_id": "D006331",
+        "umls_id": None,
+        "icd10cm_id": None,
+    },
+]
+
+TCM = [
+    {"symmap_id": "SMTS0001", "name_en": "Heat-Toxin Inflammation"},
+    {"symmap_id": "SMTS0002", "name_en": "Yang Deficiency"},
+]
+
+DISEASES = [
+    "Cancer of the lung",
+    "Hair loss alopecia",
+    "Bile insufficiency syndrome",
+    "Chronic stress disorder",
+]
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — exact case-insensitive match (preferred)
+# ---------------------------------------------------------------------------
+
+
+def test_exact_match_on_modern_symptom_returns_full_xrefs():
+    result = match_symptom("Inflammation", modern=MODERN, tcm=TCM, diseases=DISEASES)
+    assert result is not None
+    assert isinstance(result, MatchResult)
+    assert result.source == "symmap_modern"
+    assert result.match_score == 1.0
+    assert result.symmap_id == "SMMS0001"
+    assert result.mesh_id == "D007249"
+    assert result.umls_id == "C0021368"
+
+
+def test_exact_match_is_case_insensitive():
+    result = match_symptom("PAIN", modern=MODERN, tcm=TCM, diseases=DISEASES)
+    assert result is not None
+    assert result.symmap_id == "SMMS0005"
+    assert result.match_score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — token Jaccard (when exact fails, but symptom shares enough tokens)
+# ---------------------------------------------------------------------------
+
+
+def test_token_jaccard_basic():
+    assert token_jaccard("inflammation", "inflammation") == 1.0
+    assert token_jaccard("heart disease", "heart disease") == 1.0
+    # 1 shared token of 2 unique → 1/3 = ~0.333
+    assert abs(token_jaccard("heart disease", "lung disease") - 1 / 3) < 0.01
+
+
+def test_token_jaccard_returns_zero_for_disjoint_strings():
+    assert token_jaccard("foo", "bar") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — substring containment (Diabetes → "Diabetes Mellitus", etc.)
+# ---------------------------------------------------------------------------
+
+
+def test_substring_match_diabetes_finds_diabetes_mellitus():
+    """Audit acceptance: Diabetes must resolve to a MeSH-anchored row."""
+    result = match_symptom("Diabetes", modern=MODERN, tcm=TCM, diseases=DISEASES)
+    assert result is not None
+    assert result.symmap_id == "SMMS0002"
+    assert result.mesh_id == "D003920"
+    assert result.source == "symmap_modern"
+    # Substring is below 1.0 to reflect partial match.
+    assert 0.5 <= result.match_score < 1.0
+
+
+def test_substring_match_hypertension_finds_essential_hypertension():
+    """Audit acceptance: Hypertension must resolve to a MeSH-anchored row."""
+    result = match_symptom("Hypertension", modern=MODERN, tcm=TCM, diseases=DISEASES)
+    assert result is not None
+    assert result.symmap_id == "SMMS0003"
+    assert result.mesh_id == "C562386"
+
+
+def test_substring_prefers_better_token_overlap_over_random_substring():
+    """Heart disease should pick 'Acute Heart Disease' (jaccard high) — not a
+    random shorter symmap row that happens to contain 'heart'."""
+    result = match_symptom("Heart Disease", modern=MODERN, tcm=TCM, diseases=DISEASES)
+    assert result is not None
+    assert result.symmap_id == "SMMS0006"
+
+
+def test_substring_tier_prefers_row_with_mesh_id_when_tied():
+    """When multiple rows substring-match with equal token overlap, prefer
+    the one with a non-NULL mesh_id (downstream-joinable formal ID).
+
+    Real-world case: 'Hypertension' substring-matches both 'Essential
+    Hypertension' (MeSH=C562386) and 'Rebound Hypertension' (MeSH=NULL).
+    Without this tie-breaker, the picker is order-dependent.
+    """
+    modern_dual = [
+        {
+            "symmap_id": "SMMS_RB",
+            "name": "Rebound Hypertension",
+            "mesh_id": None,
+            "umls_id": None,
+            "icd10cm_id": None,
+        },
+        {
+            "symmap_id": "SMMS_ESS",
+            "name": "Essential Hypertension",
+            "mesh_id": "C562386",
+            "umls_id": "C0085580",
+            "icd10cm_id": "I10",
+        },
+    ]
+    result = match_symptom("Hypertension", modern=modern_dual, tcm=[], diseases=[])
+    assert result is not None
+    assert result.symmap_id == "SMMS_ESS", (
+        f"Expected MeSH-anchored Essential Hypertension; got "
+        f"{result.symmap_id} ({result.disease_name}) with mesh_id={result.mesh_id}"
+    )
+    assert result.mesh_id == "C562386"
+
+
+# ---------------------------------------------------------------------------
+# Tier 4 — fallback to target_diseases substring search
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_to_diseases_when_no_symmap_match():
+    """Bile insufficiency has no SymMap row in our fixture but appears in diseases."""
+    result = match_symptom(
+        "Bile insufficiency", modern=MODERN, tcm=TCM, diseases=DISEASES
+    )
+    assert result is not None
+    assert result.source == "string_match"
+    # Fallback rows have NO formal IDs.
+    assert result.mesh_id is None
+    assert result.umls_id is None
+    assert result.symmap_id is None
+    # Lower score than SymMap matches.
+    assert result.match_score < 0.7
+
+
+def test_returns_none_when_nothing_matches_anywhere():
+    result = match_symptom(
+        "Totally unknown symptom xyz", modern=MODERN, tcm=TCM, diseases=DISEASES
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Score range invariant — used by audit gate test
+# ---------------------------------------------------------------------------
+
+
+def test_content_token_tier_catches_memory_decline():
+    """Memory decline → 'Memory Loss Or Impairment' via content-token (tier 3.5).
+
+    Neither Jaccard (≥0.5) nor substring containment hit; only the
+    content-token tier rescues this. Audit acceptance: this should resolve
+    to a SymMap row with a MeSH ID.
+    """
+    modern_with_memory = MODERN + [
+        {
+            "symmap_id": "SMMS0099",
+            "name": "Memory Loss Or Impairment",
+            "mesh_id": "D008569",
+            "umls_id": None,
+            "icd10cm_id": None,
+        }
+    ]
+    result = match_symptom(
+        "Memory decline", modern=modern_with_memory, tcm=TCM, diseases=DISEASES
+    )
+    assert result is not None
+    assert result.symmap_id == "SMMS0099"
+    assert result.mesh_id == "D008569"
+    assert result.match_score == 0.4
+
+
+def test_content_token_tier_skips_stopword_only_overlap():
+    """'Low libido' should match 'Libido Decreased' on 'libido', not on 'low'."""
+    modern_with_libido = MODERN + [
+        {
+            "symmap_id": "SMMS0100",
+            "name": "Libido Decreased",
+            "mesh_id": "D007989",
+            "umls_id": None,
+            "icd10cm_id": None,
+        },
+        # A row that ONLY shares the stopword 'low' — must not be picked.
+        {
+            "symmap_id": "SMMS0101",
+            "name": "Low Birth Weight",
+            "mesh_id": "D008106",
+            "umls_id": None,
+            "icd10cm_id": None,
+        },
+    ]
+    result = match_symptom(
+        "Low libido", modern=modern_with_libido, tcm=TCM, diseases=DISEASES
+    )
+    assert result is not None
+    assert result.symmap_id == "SMMS0100", (
+        f"Expected SMMS0100 (Libido Decreased) but got {result.symmap_id} "
+        f"({result.disease_name}). Stopword 'low' should NOT anchor a match."
+    )
+
+
+def test_match_score_always_in_unit_interval():
+    """Audit gate: match_score must always be in [0, 1]."""
+    queries = [
+        "Inflammation",
+        "Diabetes",
+        "Hypertension",
+        "Pain",
+        "Heart Disease",
+        "Bile insufficiency",
+        "Hair loss",
+        "Cancer",
+    ]
+    for q in queries:
+        r = match_symptom(q, modern=MODERN, tcm=TCM, diseases=DISEASES)
+        if r is not None:
+            assert 0.0 <= r.match_score <= 1.0, (
+                f"match_score for {q!r} = {r.match_score} outside [0,1]"
+            )

--- a/shrine-diet-bioactivity/scripts/build-herbal-db.ts
+++ b/shrine-diet-bioactivity/scripts/build-herbal-db.ts
@@ -190,6 +190,31 @@ function createSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_bioactivity_pchembl ON bioactivity_evidence(pchembl);
   `);
   console.error('  ✓ Phase 1 bridge tables: compound_identity + bioactivity_evidence');
+
+  // Phase 2 — symptom→disease materialized map (audit §4.2 / KG audit Gap 2)
+  // -------------------------------------------------------------------------
+  // Eliminates the implicit string-LIKE bridge between our 47 hand-curated
+  // symptoms and target_diseases.disease_name. Joined upstream against
+  // SymMap (modern + TCM) so each symptom carries formal MeSH/UMLS/ICD-10
+  // IDs into use case A queries. Built by scripts/build_symptom_disease_map.py.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS symptom_disease_map (
+      symptom_id     TEXT NOT NULL,
+      disease_name   TEXT NOT NULL,
+      source         TEXT NOT NULL,        -- 'symmap_modern' | 'symmap_tcm' | 'string_match'
+      symmap_id      TEXT,
+      mesh_id        TEXT,
+      umls_id        TEXT,
+      icd10cm_id     TEXT,
+      match_score    REAL NOT NULL,
+      PRIMARY KEY (symptom_id, disease_name, source),
+      FOREIGN KEY (symptom_id) REFERENCES symptoms(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_sdm_symptom ON symptom_disease_map(symptom_id);
+    CREATE INDEX IF NOT EXISTS idx_sdm_mesh    ON symptom_disease_map(mesh_id);
+    CREATE INDEX IF NOT EXISTS idx_sdm_score   ON symptom_disease_map(match_score);
+  `);
+  console.error('  ✓ symptom_disease_map table');
 }
 
 // ---------------------------------------------------------------------------

--- a/shrine-diet-bioactivity/scripts/build_symptom_disease_map.py
+++ b/shrine-diet-bioactivity/scripts/build_symptom_disease_map.py
@@ -1,0 +1,203 @@
+"""Build the materialized symptom→disease map (audit §4.2).
+
+Reads:
+  - symptoms                   (47 hand-curated symptoms)
+  - symmap_modern_symptoms     (1,148 clinical symptoms with MeSH/UMLS/ICD)
+  - symmap_tcm_symptoms        (2,285 TCM symptoms via name_en)
+  - target_diseases            (795K rows, 2,976 distinct disease names)
+
+Writes:
+  - symptom_disease_map (idempotent rebuild — DELETE then INSERT in a
+    single transaction so a partial run leaves the prior contents intact).
+
+Usage:
+  python scripts/build_symptom_disease_map.py \\
+      --db data_local/herbal_botanicals.db \\
+      [--max-fallbacks-per-symptom 5]   # cap target_diseases fallbacks
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "lightrag"))
+
+from symptom_matcher import match_symptom  # noqa: E402
+
+DDL = """
+CREATE TABLE IF NOT EXISTS symptom_disease_map (
+    symptom_id     TEXT NOT NULL,
+    disease_name   TEXT NOT NULL,
+    source         TEXT NOT NULL,
+    symmap_id      TEXT,
+    mesh_id        TEXT,
+    umls_id        TEXT,
+    icd10cm_id     TEXT,
+    match_score    REAL NOT NULL,
+    PRIMARY KEY (symptom_id, disease_name, source),
+    FOREIGN KEY (symptom_id) REFERENCES symptoms(id)
+);
+CREATE INDEX IF NOT EXISTS idx_sdm_symptom    ON symptom_disease_map(symptom_id);
+CREATE INDEX IF NOT EXISTS idx_sdm_mesh       ON symptom_disease_map(mesh_id);
+CREATE INDEX IF NOT EXISTS idx_sdm_score      ON symptom_disease_map(match_score);
+"""
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    description = (__doc__ or "Build symptom_disease_map").split("\n\n")[0]
+    ap = argparse.ArgumentParser(description=description)
+    ap.add_argument("--db", type=Path, required=True)
+    ap.add_argument(
+        "--max-fallbacks-per-symptom",
+        type=int,
+        default=5,
+        help=(
+            "When tier-4 (target_diseases substring) is the only match, "
+            "cap how many disease rows to record per symptom (default: 5)."
+        ),
+    )
+    return ap
+
+
+def _load_modern(conn: sqlite3.Connection) -> list[dict]:
+    cur = conn.execute(
+        "SELECT symmap_id, name, mesh_id, umls_id, icd10cm_id "
+        "FROM symmap_modern_symptoms WHERE name IS NOT NULL"
+    )
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def _load_tcm(conn: sqlite3.Connection) -> list[dict]:
+    cur = conn.execute(
+        "SELECT symmap_id, name_en FROM symmap_tcm_symptoms WHERE name_en IS NOT NULL"
+    )
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def _load_distinct_diseases(conn: sqlite3.Connection) -> list[str]:
+    cur = conn.execute(
+        "SELECT DISTINCT disease_name FROM target_diseases "
+        "WHERE disease_name IS NOT NULL"
+    )
+    return [row[0] for row in cur.fetchall()]
+
+
+def main() -> int:
+    args = _build_argparser().parse_args()
+    if not args.db.exists():
+        print(f"ERROR: DB not found: {args.db}", file=sys.stderr)
+        return 2
+
+    conn = sqlite3.connect(str(args.db))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(DDL)
+
+    print("Loading SymMap + target_diseases ...")
+    modern = _load_modern(conn)
+    tcm = _load_tcm(conn)
+    diseases = _load_distinct_diseases(conn)
+    print(
+        f"  {len(modern)} modern symptoms, {len(tcm)} TCM symptoms, "
+        f"{len(diseases)} distinct disease names"
+    )
+
+    symptoms = [
+        {"id": row["id"], "name": row["name"]}
+        for row in conn.execute("SELECT id, name FROM symptoms ORDER BY id")
+    ]
+    print(f"  {len(symptoms)} symptoms to map")
+
+    insert_sql = """
+        INSERT OR IGNORE INTO symptom_disease_map
+          (symptom_id, disease_name, source, symmap_id, mesh_id,
+           umls_id, icd10cm_id, match_score)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    inserted = 0
+    matched_symptoms = 0
+    matched_with_mesh = 0
+    fallback_only = 0
+
+    try:
+        with conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM symptom_disease_map")
+            for s in symptoms:
+                # Primary best match.
+                best = match_symptom(
+                    s["name"], modern=modern, tcm=tcm, diseases=diseases
+                )
+                if best is None:
+                    continue
+                cur.execute(
+                    insert_sql,
+                    (
+                        s["id"],
+                        best.disease_name,
+                        best.source,
+                        best.symmap_id,
+                        best.mesh_id,
+                        best.umls_id,
+                        best.icd10cm_id,
+                        best.match_score,
+                    ),
+                )
+                inserted += 1
+                matched_symptoms += 1
+                if best.mesh_id is not None:
+                    matched_with_mesh += 1
+                if best.source == "string_match":
+                    fallback_only += 1
+
+                # Tier-4 expansion: if the primary match is a fallback, also
+                # add a few more target_diseases substring matches so the
+                # symptom has more recall in downstream queries. Capped per
+                # symptom to avoid blowup on common terms (e.g. Cancer).
+                if best.source == "string_match":
+                    extras = 0
+                    sname = s["name"].lower()
+                    for d in diseases:
+                        if extras >= args.max_fallbacks_per_symptom - 1:
+                            break
+                        dn = d.lower()
+                        if d == best.disease_name:
+                            continue
+                        if sname in dn or dn in sname:
+                            cur.execute(
+                                insert_sql,
+                                (
+                                    s["id"],
+                                    d,
+                                    "string_match",
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    0.3,
+                                ),
+                            )
+                            inserted += 1
+                            extras += 1
+
+    finally:
+        conn.close()
+
+    print(f"\nInserted {inserted} rows for {matched_symptoms}/{len(symptoms)} symptoms")
+    print(f"  with MeSH IDs:    {matched_with_mesh}")
+    print(f"  fallback (string) only: {fallback_only}")
+    if matched_symptoms < 40:
+        print(
+            "WARNING: fewer than 40/47 symptoms mapped — audit §4.2 acceptance "
+            "criterion not met. Inspect symmap_modern_symptoms.name overlap."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Resolves the highest-leverage gap from the KG completeness audit: a materialized `symptom_disease_map` table replaces the implicit string-LIKE bridge that previously sat between our 47 hand-curated symptoms and `target_diseases.disease_name`. Each symptom now carries formal MeSH / UMLS / ICD-10 cross-refs from SymMap.

**Stacked on PR #20** (`phase1.5/docs-and-kg-audit`) — that PR scaffolded the RED audit-gate tests; this PR turns 4 of them GREEN.

## Live-DB resolution coverage

- **40 / 47 symptoms mapped** (audit acceptance ≥40 ✓)
- **33 / 40 carry MeSH IDs** (downstream-joinable to PubMed / DrugBank / Open Targets)
- **1 fallback-only** (no SymMap or substring hit)
- 7 unmappable clinical-concept terms flagged as Phase 2.5 hand-curation candidates

## TDD trail (per `/tdd` semantics)

| Phase | Status |
|---|---|
| RED | `test_symptom_matcher.py` written first; `xfail` audit gates from PR #20 turn XPASS-strict (= FAIL) once impl lands |
| GREEN | 4-tier matcher + CLI + DDL + LightRAG schema entry |
| REFACTOR | mesh-id tie-breaker added when first run picked "Rebound Hypertension" over "Essential Hypertension"; content-token tier added for clinical-concept terms |

13 unit tests + 5 audit-gate tests = 18 tests all GREEN; 2 xfail tests remain for Gaps 1 (CTD) and 3 (HERB 2.0) which have their own follow-up specs.

## Algorithm — 4-tier matching

1. **Exact** (case-insensitive) → score 1.0 — covers 16/47 symptoms (Inflammation, Pain, Cancer, Anxiety, etc.)
2. **Jaccard ≥ 0.5** with mesh-id tie-breaker → score = jaccard
3. **Substring containment** → score 0.5–0.8 by token-overlap fraction; mesh-id tie-breaker
4. **Content-token** (stopword-filtered) → score 0.4 — rescues Memory decline → "Memory Loss Or Impairment", Liver damage → "Liver Cirrhosis", Low libido → "Libido Decreased"
5. **Target-diseases substring fallback** → score 0.3, no formal IDs

## Schema additions

```sql
CREATE TABLE symptom_disease_map (
  symptom_id     TEXT NOT NULL,
  disease_name   TEXT NOT NULL,
  source         TEXT NOT NULL,      -- 'symmap_modern' | 'symmap_tcm' | 'string_match'
  symmap_id      TEXT,
  mesh_id        TEXT,
  umls_id        TEXT,
  icd10cm_id     TEXT,
  match_score    REAL NOT NULL,      -- in [0, 1]
  PRIMARY KEY (symptom_id, disease_name, source),
  FOREIGN KEY (symptom_id) REFERENCES symptoms(id)
);
```

LightRAG `MAPS_TO_DISEASE` (Symptom → Disease) carries `source / mesh_id / umls_id / icd10cm_id / match_score` as edge properties. Description renderer produces strings like:

> *"Diabetes maps to disease Diabetes Mellitus (via symmap_modern, MeSH D003920, score 0.5)"*

## What it unlocks for use case A (Symptom → food)

Before: `symptom.name LIKE '%X%'` against 795K target_diseases rows — noisy, no confidence, no ranking.

After: deterministic JOIN through `symptom_disease_map` ranked by `match_score`, with formal MeSH/UMLS IDs that downstream tools (PubMed E-utilities, Open Targets, DrugBank) can use as canonical keys for further enrichment.

## Test plan

- [x] 13 matcher unit tests (4 tiers + stopword + tie-breaker + invariants) — all GREEN
- [x] 5 audit-gate tests (4 from PR #20 xfail-flipped + 1 new MAPS_TO_DISEASE entity-schema test) — all GREEN
- [x] Live-DB build run produces: 40/47 mapped, 33/40 with MeSH, idempotent re-run
- [x] Inflammation → "Inflammation" (D007249), Diabetes → "Diabetes Mellitus" (D003920), Hypertension → "Essential Hypertension" (C562386) — verified

## Out of scope (separate PRs)

- **Gap 1** — CTD `chemical_diseases` ingest (audit §4.1)
- **Gap 3** — HERB 2.0 ↔ Duke herb resolution (audit §4.3)
- **Phase 2.5** — hand-curated rescue map for the 7 remaining unmapped clinical-concept symptoms

🤖 Generated with [Claude Code](https://claude.com/claude-code)