### PR TITLE
chore: post-stack cleanup (SUBMIT.md build fixes + coverage thresholds)

### DIFF
--- a/research-journal/primary/v1/arxiv-package/.gitignore
+++ b/research-journal/primary/v1/arxiv-package/.gitignore
@@ -1,0 +1,4 @@
+# Generated artifacts (rebuild via SUBMIT.md command).
+# paper.md + references.bib + figures/ + tables/ are the canonical source.
+paper.pdf
+paper.tex

--- a/research-journal/primary/v1/arxiv-package/SUBMIT.md
+++ b/research-journal/primary/v1/arxiv-package/SUBMIT.md
@@ -2,25 +2,34 @@
 
 ## Local PDF generation
 
-Pandoc was not available in the dev environment. Run on a machine with pandoc + a LaTeX distribution:
+Verified on Ubuntu 22.04 with pandoc 2.9.2.1 + pandoc-citeproc + texlive-xetex on 2026-05-15.
 
 ```bash
 # From this directory:
 pandoc paper.md \
   --bibliography=references.bib \
-  --citeproc \
+  --filter pandoc-citeproc \
   --csl=https://www.zotero.org/styles/ieee \
+  --pdf-engine=xelatex \
   -V geometry:margin=1in \
   -V fontsize=10pt \
+  -V mainfont="DejaVu Serif" \
+  -V monofont="DejaVu Sans Mono" \
   -o paper.pdf
 ```
+
+Important flags (don't drop these):
+
+- `--filter pandoc-citeproc` — pandoc 2.x does NOT recognize the bare `--citeproc` flag; needs the filter form. (Newer pandoc 3.x uses `--citeproc` as a flag; if you're on 3.x, swap accordingly.)
+- `--pdf-engine=xelatex` + `-V mainfont="DejaVu Serif"` — required because the paper uses Greek letters (κ for inter-annotator agreement) and math symbols (≤, ≥) that the default `lmroman` font does not cover. Without these flags, those characters render as missing glyphs in the PDF.
+- `-V monofont="DejaVu Sans Mono"` — keeps inline code blocks consistent under the xelatex font stack.
 
 Note: `paper.md` includes a `# References` heading with a `<div id="refs"></div>`
 placement marker that pandoc citeproc populates in place. The appendix sections
 (A.1-A.6 in `A0-appendix.md`) are merged into `paper.md` after the bibliography
 div and are excluded from the 4-page body budget per ML4H Findings convention.
 
-For an arXiv source bundle (preferred):
+For an arXiv source bundle (preferred — let arXiv compile):
 
 ```bash
 pandoc paper.md \

--- a/shrine-diet-bioactivity/vitest.config.ts
+++ b/shrine-diet-bioactivity/vitest.config.ts
@@ -21,16 +21,18 @@ export default defineConfig({
         // coverage is expected and not meaningful here.
         'src/index.ts',
       ],
-      // Thresholds reflect current main reality + 2-point margin. They are
-      // intentionally below the org-wide 80% target while the phase PR stack
-      // (#19→#35 — KG audit-closure) lands; those PRs add tested code paths
-      // that lift tools.ts coverage substantially. Re-raise after the stack
-      // merges. See research-journal/ for the audit context.
+      // Thresholds reflect current main reality + ~2-point margin. The phase
+      // PR stack (#19→#35, all merged 2026-05-14) lifted coverage substantially.
+      // Re-measured 2026-05-15 against current main (94 tests, 12 test files):
+      //   statements 72.82  branches 71.05  functions 61.90  lines 73.71
+      // tools.ts remains the largest uncovered surface at 27.86% — closing
+      // that gap is the next coverage initiative (publication-aligned MCP
+      // tool tests).
       thresholds: {
-        statements: 63,
-        branches: 60,
-        functions: 50,
-        lines: 63,
+        statements: 70,
+        branches: 68,
+        functions: 58,
+        lines: 70,
       },
     },
   },


### PR DESCRIPTION
Two follow-ups after the audit-closure stack (#19→#35) landed 2026-05-14.

## SUBMIT.md (arxiv build commands)

The previously documented pandoc command was stale and produced PDFs with missing glyphs everywhere the paper uses κ (kappa, for inter-annotator agreement) and math symbols ≤/≥. Updated to the verified-working invocation:

\`\`\`bash
pandoc paper.md \
  --bibliography=references.bib \
  --filter pandoc-citeproc \
  --csl=https://www.zotero.org/styles/ieee \
  --pdf-engine=xelatex \
  -V geometry:margin=1in \
  -V fontsize=10pt \
  -V mainfont="DejaVu Serif" \
  -V monofont="DejaVu Sans Mono" \
  -o paper.pdf
\`\`\`

Inline rationale documents WHY each flag is required (so the next person doesn't strip them).

## Coverage thresholds (vitest.config.ts)

Phase PRs added 11 new tests (83 → 94) and raised coverage materially:

| Metric | Was-threshold | Was-actual | New-actual | New-threshold |
|---|---|---|---|---|
| Statements | 63 | 65.04 | 72.82 | 70 |
| Branches | 60 | 64.28 | 71.05 | 68 |
| Functions | 50 | 54.16 | 61.90 | 58 |
| Lines | 63 | 65.48 | 73.71 | 70 |

~2pt margin under current values so transient changes don't bounce CI, but any genuine regression now fails loud. Comment updated to record the measurement date + tools.ts as the next coverage target.

## Test plan

- [ ] CI runs the test:coverage step against new thresholds and passes.
- [ ] Local `npx vitest run --coverage` reports the same numbers in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)