### PR TITLE
fix(lightrag): repair KG ingestion pipeline for Aura Free re-ingestion

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -9,7 +9,9 @@
         "tsx",
         "./shrine-diet-bioactivity/src/index.ts"
       ],
-      "env": {}
+      "env": {
+        "LIGHTRAG_API_URL": "http://localhost:9621"
+      }
     }
   }
 }

--- a/shrine-diet-bioactivity/lightrag/ingest_unified.py
+++ b/shrine-diet-bioactivity/lightrag/ingest_unified.py
@@ -40,12 +40,58 @@ from extra_sources import (
     extract_herb2_relationships,
 )
 
+# Side-effect import: registers ScopedNeo4JStorage / ScopedNeo4JVectorStorage
+# into upstream LightRAG's storage whitelist before any LightRAG() call.
+# Without this, LightRAG.__post_init__ rejects the Scoped* storages named in
+# config_*.env. See Issue #13.
+import lightrag_init  # noqa: F401
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR = Path(__file__).parent
 DB_PATH = SCRIPT_DIR / ".." / "data_local" / "herbal_botanicals.db"
+
+
+# ---------------------------------------------------------------------------
+# Embedding — OpenAI-compatible (OpenRouter) without base64 encoding_format
+# ---------------------------------------------------------------------------
+
+
+async def _openai_compat_embed(
+    texts: list[str],
+    model: str,
+    base_url: str,
+    api_key: str | None,
+    embedding_dim: int,
+):
+    """Call an OpenAI-compatible /embeddings endpoint with float encoding.
+
+    lightrag's bundled openai_embed forces ``encoding_format="base64"``,
+    which OpenRouter rejects. This calls the endpoint directly, requests
+    default (float) encoding, and returns results in input order.
+    """
+    import httpx
+    import numpy as np
+
+    url = base_url.rstrip("/") + "/embeddings"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    payload = {"model": model, "input": texts, "dimensions": embedding_dim}
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        resp = await client.post(url, headers=headers, json=payload)
+        resp.raise_for_status()
+        body = resp.json()
+
+    data = body.get("data")
+    if not isinstance(data, list):
+        raise RuntimeError(f"embeddings endpoint returned no data: {body.get('error', body)}")
+    # Sort by `index` so embeddings line up with input order.
+    ordered = sorted(data, key=lambda d: d.get("index", 0))
+    return np.array([d["embedding"] for d in ordered], dtype=np.float32)
 
 
 # ---------------------------------------------------------------------------
@@ -430,14 +476,26 @@ async def main() -> None:
             ),
         )
     else:
-        from lightrag.llm.openai import gpt_4o_mini_complete, openai_embed
+        from lightrag.llm.openai import gpt_4o_mini_complete
         llm_func = gpt_4o_mini_complete
+        # NOTE: lightrag's openai_embed hardcodes `encoding_format="base64"`,
+        # which OpenRouter rejects ({"error":...}, no `data`) → downstream
+        # 'NoneType' object is not iterable. Use a direct OpenRouter call
+        # (float encoding) instead. api_key resolved like scoped_server.
+        embed_api_key = (
+            os.getenv("EMBEDDING_BINDING_API_KEY")
+            or os.getenv("OPENROUTER_API_KEY")
+            or os.getenv("OPENAI_API_KEY")
+        )
         embed_func = EmbeddingFunc(
             embedding_dim=embedding_dim,
             max_token_size=8192,
             func=partial(
-                openai_embed.func,
+                _openai_compat_embed,
                 model=embedding_model,
+                base_url=embedding_host,
+                api_key=embed_api_key,
+                embedding_dim=embedding_dim,
             ),
         )
 

--- a/shrine-diet-bioactivity/lightrag/ingest_unified.py
+++ b/shrine-diet-bioactivity/lightrag/ingest_unified.py
@@ -59,19 +59,33 @@ DB_PATH = SCRIPT_DIR / ".." / "data_local" / "herbal_botanicals.db"
 # ---------------------------------------------------------------------------
 
 
+# HTTP status / OpenRouter error codes worth retrying — transient upstream
+# failures (rate limit, gateway, Cloudflare 5xx). 4xx auth/bad-request codes
+# are NOT here: retrying those just wastes time.
+_TRANSIENT_HTTP_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504, 520, 522, 524})
+
+
 async def _openai_compat_embed(
     texts: list[str],
     model: str,
     base_url: str,
     api_key: str | None,
     embedding_dim: int,
+    max_retries: int = 5,
 ):
     """Call an OpenAI-compatible /embeddings endpoint with float encoding.
 
     lightrag's bundled openai_embed forces ``encoding_format="base64"``,
     which OpenRouter rejects. This calls the endpoint directly, requests
     default (float) encoding, and returns results in input order.
+
+    Transient failures (HTTP 429/5xx, network errors, and OpenRouter's
+    200-with-error-body for upstream 5xx) are retried with exponential
+    backoff. Without this, one transient blip silently drops a whole
+    ingest batch — its entities never get embedded or written.
     """
+    import asyncio as _asyncio
+
     import httpx
     import numpy as np
 
@@ -81,17 +95,46 @@ async def _openai_compat_embed(
         headers["Authorization"] = f"Bearer {api_key}"
     payload = {"model": model, "input": texts, "dimensions": embedding_dim}
 
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        resp = await client.post(url, headers=headers, json=payload)
-        resp.raise_for_status()
-        body = resp.json()
+    last_err: Exception | None = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                resp = await client.post(url, headers=headers, json=payload)
+                resp.raise_for_status()
+                body = resp.json()
 
-    data = body.get("data")
-    if not isinstance(data, list):
-        raise RuntimeError(f"embeddings endpoint returned no data: {body.get('error', body)}")
-    # Sort by `index` so embeddings line up with input order.
-    ordered = sorted(data, key=lambda d: d.get("index", 0))
-    return np.array([d["embedding"] for d in ordered], dtype=np.float32)
+            data = body.get("data")
+            if isinstance(data, list):
+                # A missing `index` must fail loudly — a default sort key
+                # would collapse items to 0 and misalign embeddings.
+                if any("index" not in d for d in data):
+                    raise RuntimeError(f"embeddings response item missing 'index': {data[:2]}")
+                ordered = sorted(data, key=lambda d: d["index"])
+                return np.array([d["embedding"] for d in ordered], dtype=np.float32)
+
+            # No `data`: OpenRouter returns HTTP 200 with {"message":...,
+            # "code":520} when its upstream fails. Retry transient codes.
+            err = body.get("error", body)
+            code = err.get("code") if isinstance(err, dict) else None
+            if code in _TRANSIENT_HTTP_CODES and attempt < max_retries:
+                last_err = RuntimeError(f"transient embeddings error: {err}")
+            else:
+                raise RuntimeError(f"embeddings endpoint returned no data: {err}")
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in _TRANSIENT_HTTP_CODES and attempt < max_retries:
+                last_err = exc
+            else:
+                raise
+        except httpx.RequestError as exc:
+            # Network-level failure (timeout, connection reset) — transient.
+            if attempt < max_retries:
+                last_err = exc
+            else:
+                raise
+
+        await _asyncio.sleep(min(2 ** attempt, 30))
+
+    raise RuntimeError(f"embeddings failed after {max_retries} attempts: {last_err}")
 
 
 # ---------------------------------------------------------------------------

--- a/shrine-diet-bioactivity/lightrag/test_ingest_embed.py
+++ b/shrine-diet-bioactivity/lightrag/test_ingest_embed.py
@@ -1,0 +1,357 @@
+"""Tests for _openai_compat_embed — the OpenRouter-compatible embed call.
+
+lightrag's bundled openai_embed hardcodes ``encoding_format="base64"``,
+which OpenRouter rejects (returns ``{"error": ...}`` with no ``data``),
+producing a downstream ``'NoneType' object is not iterable``. The ingest
+script replaces it with ``_openai_compat_embed`` — a direct call that
+uses float encoding and passes base_url / api_key explicitly.
+
+These tests pin that contract so the base64 regression cannot return:
+  - the request payload must NOT carry ``encoding_format``
+  - missing ``data`` must raise a clear error, not crash downstream
+  - results must come back in input order regardless of response order
+
+Usage:
+    python -m pytest test_ingest_embed.py -v
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import numpy as np
+import pytest
+
+from ingest_unified import _openai_compat_embed
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# httpx mock plumbing
+# ---------------------------------------------------------------------------
+
+
+def _mock_httpx(response_body: dict, *, raise_status: Exception | None = None):
+    """Build a patch target for httpx.AsyncClient.
+
+    Returns a MagicMock suitable for ``patch("httpx.AsyncClient", ...)``.
+    The client is used as ``async with httpx.AsyncClient(...) as client``.
+    """
+    resp = MagicMock()
+    resp.json.return_value = response_body
+    if raise_status is not None:
+        resp.raise_for_status = MagicMock(side_effect=raise_status)
+    else:
+        resp.raise_for_status = MagicMock(return_value=None)
+
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+
+    factory = MagicMock(return_value=ctx)
+    # expose the inner post mock so tests can assert on the request
+    factory._post = client.post
+    return factory
+
+
+def _embedding_response(vectors: list[list[float]]) -> dict:
+    """OpenAI-shaped embeddings response, items in input order (index == position)."""
+    data = [
+        {"object": "embedding", "index": i, "embedding": vec}
+        for i, vec in enumerate(vectors)
+    ]
+    return {"object": "list", "data": data, "model": "test-model"}
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_returns_float32_array_of_right_shape():
+    factory = _mock_httpx(_embedding_response([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]))
+    with patch("httpx.AsyncClient", factory):
+        out = asyncio.run(
+            _openai_compat_embed(
+                ["a", "b"], model="m", base_url="https://x/api/v1",
+                api_key="k", embedding_dim=3,
+            )
+        )
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (2, 3)
+    assert out.dtype == np.float32
+
+
+def test_request_payload_has_no_encoding_format():
+    """The base64 regression guard — encoding_format must never be sent."""
+    factory = _mock_httpx(_embedding_response([[1.0, 2.0]]))
+    with patch("httpx.AsyncClient", factory):
+        asyncio.run(
+            _openai_compat_embed(
+                ["only"], model="nv-embed", base_url="https://openrouter.ai/api/v1",
+                api_key="k", embedding_dim=2,
+            )
+        )
+    sent = factory._post.await_args.kwargs["json"]
+    assert "encoding_format" not in sent, "encoding_format=base64 is the OpenRouter-incompatible bug"
+    assert sent["model"] == "nv-embed"
+    assert sent["input"] == ["only"]
+    assert sent["dimensions"] == 2
+
+
+def test_results_sorted_by_response_index():
+    """Round-trip proof: output row i must hold the embedding the provider
+    tagged index=i, regardless of the order items appear in the response list.
+
+    The contract: input "x"→index 0→[1.0], "y"→1→[2.0], "z"→2→[3.0]. The
+    response lists them scrambled; the function must re-sort to input order.
+    """
+    body = {"data": [
+        {"index": 2, "embedding": [3.0]},   # belongs to input "z"
+        {"index": 0, "embedding": [1.0]},   # belongs to input "x"
+        {"index": 1, "embedding": [2.0]},   # belongs to input "y"
+    ]}
+    factory = _mock_httpx(body)
+    with patch("httpx.AsyncClient", factory):
+        out = asyncio.run(
+            _openai_compat_embed(
+                ["x", "y", "z"], model="m", base_url="https://x/v1",
+                api_key="k", embedding_dim=1,
+            )
+        )
+    # Scrambled list order + explicit index → output reconstructed in input order.
+    assert out.flatten().tolist() == [1.0, 2.0, 3.0]
+
+
+def test_missing_index_field_raises():
+    """An item without `index` must fail loudly — a default sort key would
+    silently misalign embeddings with their source texts."""
+    body = {"data": [
+        {"embedding": [1.0]},               # no `index`
+        {"index": 1, "embedding": [2.0]},
+    ]}
+    factory = _mock_httpx(body)
+    with patch("httpx.AsyncClient", factory):
+        with pytest.raises(RuntimeError, match="index"):
+            asyncio.run(
+                _openai_compat_embed(
+                    ["a", "b"], model="m", base_url="https://x/v1",
+                    api_key="k", embedding_dim=1,
+                )
+            )
+
+
+def test_base_url_trailing_slash_is_stripped():
+    factory = _mock_httpx(_embedding_response([[1.0]]))
+    with patch("httpx.AsyncClient", factory):
+        asyncio.run(
+            _openai_compat_embed(
+                ["a"], model="m", base_url="https://x/api/v1/",
+                api_key="k", embedding_dim=1,
+            )
+        )
+    url = factory._post.await_args.args[0]
+    assert url == "https://x/api/v1/embeddings"
+
+
+# ---------------------------------------------------------------------------
+# Auth header
+# ---------------------------------------------------------------------------
+
+
+def test_authorization_header_present_with_api_key():
+    factory = _mock_httpx(_embedding_response([[1.0]]))
+    with patch("httpx.AsyncClient", factory):
+        asyncio.run(
+            _openai_compat_embed(
+                ["a"], model="m", base_url="https://x/v1",
+                api_key="secret-token", embedding_dim=1,
+            )
+        )
+    headers = factory._post.await_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer secret-token"
+
+
+def test_authorization_header_omitted_when_api_key_none():
+    factory = _mock_httpx(_embedding_response([[1.0]]))
+    with patch("httpx.AsyncClient", factory):
+        asyncio.run(
+            _openai_compat_embed(
+                ["a"], model="m", base_url="https://x/v1",
+                api_key=None, embedding_dim=1,
+            )
+        )
+    headers = factory._post.await_args.kwargs["headers"]
+    assert "Authorization" not in headers
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_missing_data_raises_runtime_error():
+    """OpenRouter rejects bad params with {"error": ...} and no data —
+    must raise a clear error, not 'NoneType is not iterable' downstream."""
+    factory = _mock_httpx({"error": {"message": "unsupported encoding_format"}})
+    with patch("httpx.AsyncClient", factory):
+        with pytest.raises(RuntimeError, match="no data|error"):
+            asyncio.run(
+                _openai_compat_embed(
+                    ["a"], model="m", base_url="https://x/v1",
+                    api_key="k", embedding_dim=1,
+                )
+            )
+
+
+def test_data_not_a_list_raises_runtime_error():
+    factory = _mock_httpx({"data": None})
+    with patch("httpx.AsyncClient", factory):
+        with pytest.raises(RuntimeError):
+            asyncio.run(
+                _openai_compat_embed(
+                    ["a"], model="m", base_url="https://x/v1",
+                    api_key="k", embedding_dim=1,
+                )
+            )
+
+
+def test_http_error_propagates():
+    """A non-transient 4xx from the endpoint must not be swallowed."""
+    factory = _mock_httpx({}, raise_status=RuntimeError("boom"))
+    with patch("httpx.AsyncClient", factory):
+        with pytest.raises(RuntimeError, match="boom"):
+            asyncio.run(
+                _openai_compat_embed(
+                    ["a"], model="m", base_url="https://x/v1",
+                    api_key="k", embedding_dim=1,
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# Transient-failure retry
+# ---------------------------------------------------------------------------
+
+
+def _mock_httpx_sequence(items: list):
+    """httpx.AsyncClient factory whose .post yields `items` across calls.
+
+    Each item is either a response body dict (HTTP 200) or an Exception
+    instance to raise. The retry loop creates a fresh client per attempt,
+    but the post mock is shared, so side_effect advances per attempt.
+    """
+    side_effects = []
+    for it in items:
+        if isinstance(it, Exception):
+            side_effects.append(it)
+        else:
+            resp = MagicMock()
+            resp.json.return_value = it
+            resp.raise_for_status = MagicMock(return_value=None)
+            side_effects.append(resp)
+
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=side_effects)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    factory = MagicMock(return_value=ctx)
+    factory._post = client.post
+    return factory
+
+
+def _http_status_error(code: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "https://x/v1/embeddings")
+    resp = httpx.Response(code, request=req)
+    return httpx.HTTPStatusError(f"HTTP {code}", request=req, response=resp)
+
+
+def test_retries_transient_520_body_then_succeeds():
+    """OpenRouter's 200-with-{'code':520} body is transient → retry, then win."""
+    factory = _mock_httpx_sequence([
+        {"message": "HTTP 520: error code: 520", "code": 520},  # transient
+        _embedding_response([[1.0, 2.0]]),                       # recovered
+    ])
+    with patch("httpx.AsyncClient", factory), patch("asyncio.sleep", new=AsyncMock()):
+        out = asyncio.run(
+            _openai_compat_embed(
+                ["a"], model="m", base_url="https://x/v1",
+                api_key="k", embedding_dim=2, max_retries=4,
+            )
+        )
+    assert out.shape == (1, 2)
+    assert factory._post.await_count == 2
+
+
+def test_retries_transient_http_503_then_succeeds():
+    factory = _mock_httpx_sequence([
+        _http_status_error(503),               # transient gateway error
+        _embedding_response([[9.0]]),          # recovered
+    ])
+    with patch("httpx.AsyncClient", factory), patch("asyncio.sleep", new=AsyncMock()):
+        out = asyncio.run(
+            _openai_compat_embed(
+                ["a"], model="m", base_url="https://x/v1",
+                api_key="k", embedding_dim=1, max_retries=4,
+            )
+        )
+    assert out.flatten().tolist() == [9.0]
+    assert factory._post.await_count == 2
+
+
+def test_permanent_http_400_not_retried():
+    """A 400 is a client error — retrying is pointless; fail on first attempt."""
+    factory = _mock_httpx_sequence([
+        _http_status_error(400),
+        _embedding_response([[1.0]]),  # never reached
+    ])
+    with patch("httpx.AsyncClient", factory), patch("asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(httpx.HTTPStatusError):
+            asyncio.run(
+                _openai_compat_embed(
+                    ["a"], model="m", base_url="https://x/v1",
+                    api_key="k", embedding_dim=1, max_retries=4,
+                )
+            )
+    assert factory._post.await_count == 1, "400 must not be retried"
+
+
+def test_retries_exhausted_raises():
+    """Persistent transient failure → raise after max_retries attempts."""
+    factory = _mock_httpx_sequence([
+        {"message": "HTTP 520", "code": 520},
+        {"message": "HTTP 520", "code": 520},
+        {"message": "HTTP 520", "code": 520},
+    ])
+    with patch("httpx.AsyncClient", factory), patch("asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(RuntimeError, match="after 3 attempts|no data"):
+            asyncio.run(
+                _openai_compat_embed(
+                    ["a"], model="m", base_url="https://x/v1",
+                    api_key="k", embedding_dim=1, max_retries=3,
+                )
+            )
+    assert factory._post.await_count == 3
+
+
+def test_network_error_is_retried():
+    """httpx.RequestError (timeout / connection reset) is transient."""
+    factory = _mock_httpx_sequence([
+        httpx.ConnectError("connection reset"),
+        _embedding_response([[5.0]]),
+    ])
+    with patch("httpx.AsyncClient", factory), patch("asyncio.sleep", new=AsyncMock()):
+        out = asyncio.run(
+            _openai_compat_embed(
+                ["a"], model="m", base_url="https://x/v1",
+                api_key="k", embedding_dim=1, max_retries=4,
+            )
+        )
+    assert out.flatten().tolist() == [5.0]
+    assert factory._post.await_count == 2

--- a/shrine-diet-bioactivity/scripts/modal_ingest_runner.py
+++ b/shrine-diet-bioactivity/scripts/modal_ingest_runner.py
@@ -1,0 +1,213 @@
+"""Modal cloud runner for the LightRAG KG ingestion.
+
+Why a cloud runner: the local WSL2 → Aura TLS path drops mid-write
+(SSLV3_ALERT_BAD_RECORD_MAC) and runs out of memory on multi-hour
+ingests. Modal provides a clean network path to Aura and stable
+container resources.
+
+Setup (one-time):
+    # Save the Infisical machine-identity token as a Modal Secret.
+    # The function uses this to fetch the actual Aura + OpenRouter
+    # credentials from Infisical at runtime, so secrets never live on
+    # disk anywhere in the runner image.
+    modal secret create kg-mcp-infisical \\
+        INFISICAL_TOKEN=ak-gs3IFfLQcx7Eyo0toi36wQ
+
+    # Upload the herbal_botanicals.db (≈ 6.3 GB) to the Modal volume.
+    # Runs once; subsequent ingestion invocations reuse the volume.
+    modal volume create kg-mcp-data
+    modal volume put kg-mcp-data \\
+        shrine-diet-bioactivity/data_local/herbal_botanicals.db \\
+        /data/herbal_botanicals.db
+
+Run:
+    modal run scripts/modal_ingest_runner.py::ingest
+
+Idempotent — re-runs MERGE into Aura, filling whatever's missing.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import modal
+
+# ─── Modal app + image ────────────────────────────────────────────────────
+
+APP_NAME = "kg-mcp-ingest"
+
+# Image: Python + the runtime deps the ingest needs. lightrag-hku is the
+# upstream LightRAG package — must match the local-dev pin.
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install(
+        "lightrag-hku>=1.4",
+        "neo4j>=5.26",
+        "numpy>=1.26",
+        "httpx>=0.27",
+        "python-dotenv>=1.0",
+        "nano-vectordb>=0.0.4",
+    )
+    # The lightrag/ source dir holds the custom storages + ingest script.
+    # Mount it from the repo so we don't have to bake a per-commit image.
+    .add_local_dir(
+        local_path=os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "lightrag",
+        ),
+        remote_path="/app/lightrag",
+    )
+)
+
+app = modal.App(APP_NAME, image=image)
+
+# Persistent volume holding the SQLite source DB. The ingest reads it
+# heavily but never modifies it — so the volume is read-mostly.
+data_volume = modal.Volume.from_name("kg-mcp-data", create_if_missing=True)
+
+# Secret containing the Infisical machine-identity token. Fetched
+# secrets (Aura, OpenRouter) are loaded into env at function start.
+infisical_secret = modal.Secret.from_name("kg-mcp-infisical")
+
+
+# ─── Infisical fetch helper ───────────────────────────────────────────────
+
+
+INFISICAL_WORKSPACE = "687cab01-ccc1-4789-99a9-1214bd268f2b"
+INFISICAL_ENV = "prod"
+INFISICAL_PATH = "/research/shrine-diet-bioactivity"
+REQUIRED_KEYS = (
+    "NEO4J_URI",
+    "NEO4J_USERNAME",
+    "NEO4J_PASSWORD",
+    "NEO4J_DATABASE",
+    "OPENROUTER_API_KEY",
+)
+
+
+def _load_secrets_into_env(token: str) -> None:
+    """Fetch the canonical Aura + OpenRouter creds from Infisical and
+    push them into os.environ for the ingestion subprocess.
+    """
+    import httpx
+
+    headers = {"Authorization": f"Bearer {token}"}
+    r = httpx.get(
+        "https://app.infisical.com/api/v3/secrets/raw",
+        params={
+            "workspaceId": INFISICAL_WORKSPACE,
+            "environment": INFISICAL_ENV,
+            "secretPath": INFISICAL_PATH,
+        },
+        headers=headers,
+        timeout=30.0,
+    )
+    r.raise_for_status()
+    secrets = {s["secretKey"]: s["secretValue"] for s in r.json().get("secrets", [])}
+
+    missing = [k for k in REQUIRED_KEYS if k not in secrets and k != "NEO4J_DATABASE"]
+    if missing:
+        raise RuntimeError(f"Infisical missing required keys: {missing}")
+
+    for k in REQUIRED_KEYS:
+        if k in secrets:
+            os.environ[k] = secrets[k]
+    # Length-only debug — never echo the secret value
+    print(
+        "secrets loaded:",
+        {k: f"len={len(os.environ.get(k, ''))}" for k in REQUIRED_KEYS},
+    )
+
+
+# ─── The ingest function ──────────────────────────────────────────────────
+
+
+@app.function(
+    image=image,
+    secrets=[infisical_secret],
+    volumes={"/data": data_volume},
+    timeout=60 * 60 * 4,  # 4 hours — generous; idempotent so safe to re-run
+    cpu=2.0,
+    memory=8192,  # 8 GB — local v6 hit OOM around 3 GB
+)
+def ingest(
+    only_relationships: str = (
+        "CONTAINS_COMPOUND,FOUND_IN_FOOD,TREATS_SYMPTOM,ASSOCIATED_WITH_DISEASE,"
+        "TARGETS_PROTEIN,COMPOUND_TREATS_DISEASE,COMPOUND_MARKER_FOR_DISEASE,"
+        "PATHWAY_INCLUDES_TARGET,MAPS_TO_DISEASE"
+    ),
+    max_relationships: int = 50_000,
+    batch_size: int = 2000,
+) -> dict:
+    """Run ingest_unified.py against the Aura instance referenced in
+    Infisical, restricted to the MCP-relevant edge types. Returns a
+    summary of the final Aura node/edge counts.
+    """
+    token = os.environ.get("INFISICAL_TOKEN")
+    if not token:
+        raise RuntimeError("INFISICAL_TOKEN not present — check Modal Secret")
+    _load_secrets_into_env(token)
+
+    # Vectors stay in NanoVectorDB locally (in the container's ephemeral FS)
+    # — the Aura Free instance cannot hold them.
+    os.environ["LIGHTRAG_VECTOR_STORAGE"] = "NanoVectorDBStorage"
+
+    # The ingest expects the SQLite at ../data_local/ relative to the
+    # lightrag/ dir. We mount the volume at /data — symlink the file in.
+    os.makedirs("/app/data_local", exist_ok=True)
+    src = "/data/herbal_botanicals.db"
+    dst = "/app/data_local/herbal_botanicals.db"
+    if not os.path.exists(dst):
+        os.symlink(src, dst)
+
+    cmd = [
+        sys.executable, "-u", "ingest_unified.py",
+        "--config", "local",
+        "--batch-size", str(batch_size),
+        "--max-relationships", str(max_relationships),
+        "--only-relationships", only_relationships,
+    ]
+    print("running:", " ".join(cmd), flush=True)
+    proc = subprocess.run(cmd, cwd="/app/lightrag", check=False)
+    print(f"ingest exit code: {proc.returncode}", flush=True)
+
+    # Final Aura snapshot
+    from neo4j import GraphDatabase
+    with GraphDatabase.driver(
+        os.environ["NEO4J_URI"],
+        auth=(os.environ["NEO4J_USERNAME"], os.environ["NEO4J_PASSWORD"]),
+    ) as drv:
+        with drv.session() as s:
+            nodes = s.run("MATCH (n) RETURN count(n) AS c").single()["c"]
+            rels = s.run("MATCH ()-[r]->() RETURN count(r) AS c").single()["c"]
+            by_rel = {
+                r["t"]: r["c"]
+                for r in s.run(
+                    "MATCH ()-[r]->() RETURN type(r) AS t, count(r) AS c"
+                )
+            }
+    return {
+        "exit_code": proc.returncode,
+        "aura_nodes": nodes,
+        "aura_rels": rels,
+        "edges_by_type": by_rel,
+    }
+
+
+@app.local_entrypoint()
+def main(
+    only_relationships: str = (
+        "CONTAINS_COMPOUND,FOUND_IN_FOOD,TREATS_SYMPTOM,ASSOCIATED_WITH_DISEASE,"
+        "TARGETS_PROTEIN,COMPOUND_TREATS_DISEASE,COMPOUND_MARKER_FOR_DISEASE,"
+        "PATHWAY_INCLUDES_TARGET,MAPS_TO_DISEASE"
+    ),
+    max_relationships: int = 50_000,
+    batch_size: int = 2000,
+):
+    out = ingest.remote(
+        only_relationships=only_relationships,
+        max_relationships=max_relationships,
+        batch_size=batch_size,
+    )
+    print("RESULT:", out)


### PR DESCRIPTION
## Summary

Repairs three latent breakages in the LightRAG KG ingestion (`ingest_unified.py`) that surfaced when re-running against a fresh Neo4j Aura **Free** instance — none had been exercised since the pipeline last ran against the prior (paid) Aura instance.

1. **Custom storages not registered** — `ingest_unified.py` built `LightRAG()` with `ScopedNeo4JStorage` / `ScopedNeo4JVectorStorage` (named in `config_*.env`) but never imported the modules that register them, so `LightRAG.__post_init__` rejected them. Fixed with a side-effect `import lightrag_init`.

2. **Embedding incompatible with OpenRouter** — the `openai` embedding branch passed neither `base_url` nor `api_key`, and lightrag's bundled `openai_embed` hardcodes `encoding_format="base64"`, which OpenRouter rejects (`{"error":...}` with no `data`) → downstream `'NoneType' object is not iterable`. Replaced with `_openai_compat_embed`: a direct OpenRouter `/embeddings` call using float encoding, explicit `base_url`/`api_key`, and input-order-stable results.

3. **Transient failures silently dropped batches** — one HTTP 520 (Cloudflare/OpenRouter upstream blip) failed an entire ingest batch with no retry; its entities were never embedded or written. `_openai_compat_embed` now retries HTTP 429/5xx, network errors, and OpenRouter's 200-with-`{"code":520}` body with exponential backoff; non-transient 4xx still fail fast.

A code review (code-reviewer agent) additionally caught a silent-misalignment bug — a missing `index` field defaulted to sort-key `0`, collapsing embeddings onto the wrong source texts. Now raises loudly.

## Tests

New `test_ingest_embed.py` — **15 unit tests**, all passing:
- base64-regression guard (payload must never carry `encoding_format`)
- request-payload contract, `base_url` trailing-slash handling, auth header present/absent
- input-order round-trip (scrambled response + explicit `index` → reconstructed order)
- missing-`index` and missing-`data` error paths
- transient-retry / fail-fast matrix (520 body, HTTP 503, network error → retried; HTTP 400 → not retried; exhaustion → raises)

## Test plan

- [x] `pytest test_ingest_embed.py` — 15/15 pass
- [x] `pytest test_ingest.py` — 40/42 pass (2 failures are **pre-existing on `origin/main`**: stale magic-number assertions in `test_ingest.py::TestEntitySchema`, unrelated to this change)
- [x] Live re-ingestion against Aura Free `b7dbceab` reaches the relationship-ingest phase (all prior runs died in entity ingest)

## Notes

- Vectors are ingested to local NanoVectorDB (not Aura) — `ScopedNeo4JVectorStorage`'s synthetic vector nodes would alone exceed the Aura Free 200K node cap.
- Out of scope (tracked in SYN-82): post-ingestion validation, docs, Aura password rotation, and a stale `railway status --json` parser in `deploy-mcp.yml`.

Linear: **SYN-82** — https://linear.app/syntropyhealth/issue/SYN-82/repair-kg-ingestion-pipeline-migrate-to-aura-free-b7dbceab