### PR TITLE
fix(ci): remove stale PR Promotion Guard (#46)

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -100,23 +100,6 @@ jobs:
           echo "is_prod=$IS_PROD" >> $GITHUB_OUTPUT
 
   # =========================================================================
-  # PR promotion guard: PRs to main must come from `test`
-  # =========================================================================
-  pr-promotion-guard:
-    name: PR Promotion Guard
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.base_ref == 'main'
-    steps:
-      - name: Require head_ref=test for PRs to main
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          if [ "$HEAD_REF" != "test" ]; then
-            echo "::error::PRs to main must come from the 'test' branch (got '$HEAD_REF')."
-            exit 1
-          fi
-
-  # =========================================================================
   # Unit tests — MCP gateway (89% coverage already)
   # =========================================================================
   test-mcp:

--- a/mcp/tests/unit/test_deploy_workflow.py
+++ b/mcp/tests/unit/test_deploy_workflow.py
@@ -167,3 +167,43 @@ class TestResolveRailwayDomain:
         rc, out = self._run("{}", service="kg-mcp", env="prod")
         assert rc == 0
         assert out == "kg-mcp-prod.up.railway.app"
+
+
+# ─── Stale promotion guard (issue #46) ────────────────────────────────────
+
+
+class TestNoStalePromotionGuard:
+    """The test→main promotion guard predates the live workflow: the `test`
+    branch is hundreds of commits behind main and effectively dead, so the
+    guard fails on every PR for no operational reason. Lock its removal in
+    so it can't quietly come back."""
+
+    def _workflow(self) -> dict:
+        return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+    def test_pr_promotion_guard_job_is_absent(self):
+        jobs = self._workflow()["jobs"]
+        assert "pr-promotion-guard" not in jobs, (
+            "The pr-promotion-guard job has been removed (see #46) — "
+            "do not reintroduce it without also reactivating the test branch."
+        )
+
+    def test_no_other_job_depends_on_promotion_guard(self):
+        """Sanity: even after removal, ensure nothing in `needs:` still
+        names the deleted job (which would silently fail to schedule)."""
+        jobs = self._workflow()["jobs"]
+        for name, body in jobs.items():
+            needs = body.get("needs") or []
+            if isinstance(needs, str):
+                needs = [needs]
+            assert "pr-promotion-guard" not in needs, (
+                f"job {name!r} still has pr-promotion-guard in its needs"
+            )
+
+    def test_no_step_step_references_promotion_guard(self):
+        """Catch leftover step-name strings (e.g., `name: PR Promotion Guard`).
+        Stronger than the job-key check because step-name strings are easy
+        to copy-paste."""
+        text = WORKFLOW_PATH.read_text()
+        assert "PR Promotion Guard" not in text
+        assert "pr-promotion-guard" not in text


### PR DESCRIPTION
## Summary

Removes the \`PR Promotion Guard\` job from \`deploy-mcp.yml\` (issue #46).

- \`test\` branch is 125+ commits behind main and effectively orphaned
- Guard never blocked merges (no branch protection on main) but failed on every PR and added noise
- After PR #70 routed main→test for deploys, the guard's premise is also weaker

## Test plan

- [x] `pytest mcp/tests/unit/test_deploy_workflow.py::TestNoStalePromotionGuard` — 3/3 pass (asserts job absent + no `needs:` ref + no leftover text)
- [x] Full `pytest mcp/tests/` — 116/116 pass
- [ ] CI on this PR: no more \`PR Promotion Guard\` failing check
- [ ] Post-merge: deploy run on main stays green (no regression from PR #70's pipeline)

## Risk

Minimal. No branch protection currently relies on this job; removing it strictly *reduces* false-failed checks. The three regression tests prevent silent reintroduction.

Closes #46.