### PR TITLE
fix(kegg): cache-key collision + retry double-sleep (#60 #61)

### DIFF
--- a/shrine-diet-bioactivity/lightrag/kegg_client.py
+++ b/shrine-diet-bioactivity/lightrag/kegg_client.py
@@ -17,12 +17,25 @@ machine. Cache invalidation = manual delete of the file.
 
 from __future__ import annotations
 
+import hashlib
 import re
 import time
 from pathlib import Path
 from typing import Optional
 
 KEGG_BASE = "https://rest.kegg.jp"
+
+
+def _batch_cache_key(batch: list[str]) -> str:
+    """Build a collision-resistant cache key for a gene-ID batch (#60).
+
+    Earlier shape ``list_genes_batch_{len}_{first_id}`` collided whenever
+    two batches happened to share length + first element. Now hash the
+    full sorted-tuple of IDs so equal batches reuse one cache entry but
+    distinct batches always diverge.
+    """
+    digest = hashlib.sha1("\n".join(sorted(batch)).encode("utf-8")).hexdigest()[:16]
+    return f"list_genes_batch_{len(batch)}_{digest}"
 DEFAULT_TIMEOUT_S = 30.0
 DEFAULT_RATE_LIMIT_SLEEP_S = 0.35  # KEGG soft limit ~3 req/s
 DEFAULT_BATCH_SIZE = 50  # /list/<a+b+c> — keep URL length manageable
@@ -142,7 +155,14 @@ class KeggClient:
         return self.cache_dir / f"{flat}.tsv"
 
     def _get(self, endpoint: str, *, cache_key: Optional[str] = None) -> str:
-        """GET; cache; retry on 5xx; return body or '' on persistent failure."""
+        """GET; cache; retry on 5xx; return body or '' on persistent failure.
+
+        Sleep discipline (#61): 5xx / network error → exponential backoff
+        only (a polite rate-limit sleep on top would just double the wait).
+        200 success → polite rate-limit sleep before returning, so the
+        *next* call respects KEGG's rate limit. 4xx → no sleep; client
+        error is final.
+        """
         import httpx
 
         key = cache_key or endpoint
@@ -157,10 +177,10 @@ class KeggClient:
             except httpx.RequestError:
                 time.sleep(self.rate_limit_sleep_s * (2**attempt))
                 continue
-            time.sleep(self.rate_limit_sleep_s)
             if resp.status_code == 200:
                 self.cache_dir.mkdir(parents=True, exist_ok=True)
                 cache_file.write_text(resp.text)
+                time.sleep(self.rate_limit_sleep_s)
                 return resp.text
             if 500 <= resp.status_code < 600:
                 time.sleep(self.rate_limit_sleep_s * (2**attempt))
@@ -231,7 +251,7 @@ class KeggClient:
             joined = "+".join(batch)
             body = self._get(
                 f"/list/{joined}",
-                cache_key=f"list_genes_batch_{len(batch)}_{batch[0].replace(':', '_')}",
+                cache_key=_batch_cache_key(batch),
             )
             out.update(parse_gene_aliases(body))
         return out

--- a/shrine-diet-bioactivity/lightrag/tests/test_kegg_client.py
+++ b/shrine-diet-bioactivity/lightrag/tests/test_kegg_client.py
@@ -195,3 +195,86 @@ def test_client_resolve_gene_symbols_batches_by_chunk(tmp_path):
     assert out == {"hsa:1": "A", "hsa:2": "B", "hsa:3": "C"}
     # 3 IDs in one batch (batch_size=10 ≥ 3).
     assert mock_get.call_count == 1
+
+
+# ---- Issue #60: cache-key collision across distinct batches ------------
+
+
+def test_resolve_gene_symbols_cache_distinguishes_batches_with_same_len_and_first_id(tmp_path):
+    """Two distinct batches with identical ``len`` and identical ``batch[0]``
+    must NOT share a cache file.
+
+    Before the fix, the key was ``list_genes_batch_{len(batch)}_{batch[0]}``
+    so batches ``[hsa:1, hsa:2]`` and ``[hsa:1, hsa:9999]`` collided →
+    the second batch silently served stale results from the first.
+
+    The fix must produce different cache files for the two batches.
+    """
+    cache_dir = tmp_path / "kegg_cache"
+    resp_a = httpx.Response(status_code=200, text="hsa:1\tA\nhsa:2\tB\n")
+    resp_b = httpx.Response(status_code=200, text="hsa:1\tA\nhsa:9999\tZ\n")
+
+    # First call: batch A
+    with patch("httpx.get", return_value=resp_a):
+        client = KeggClient(cache_dir=cache_dir, batch_size=10, rate_limit_sleep_s=0)
+        out_a = client.resolve_gene_symbols(["hsa:1", "hsa:2"])
+    assert out_a == {"hsa:1": "A", "hsa:2": "B"}
+
+    # Second call: batch B (same length=2, same first=hsa:1, different second)
+    with patch("httpx.get", return_value=resp_b):
+        client = KeggClient(cache_dir=cache_dir, batch_size=10, rate_limit_sleep_s=0)
+        out_b = client.resolve_gene_symbols(["hsa:1", "hsa:9999"])
+
+    # The fix is observable as: batch B's lookup hit the HTTP layer (no
+    # cache collision served stale A). out_b must include hsa:9999.
+    assert "hsa:9999" in out_b, (
+        "Cache key collision: batch B served stale data from batch A "
+        "(see #60)."
+    )
+
+
+# ---- Issue #61: unconditional rate-limit sleep doubles retry wait -------
+
+
+def test_get_does_not_double_sleep_on_5xx_retry(tmp_path, monkeypatch):
+    """On a 5xx response, the retry backoff is the only delay; the polite
+    rate-limit sleep must NOT also fire on the same attempt.
+
+    Before the fix, the polite ``time.sleep(rate_limit_sleep_s)`` fired
+    after EVERY HTTP response, so a 5xx retry waited
+    ``rate_limit_sleep_s + rate_limit_sleep_s * 2**attempt``. With the
+    fix, only the backoff fires on the failure path.
+    """
+    sleeps: list[float] = []
+    monkeypatch.setattr("kegg_client.time.sleep", lambda s: sleeps.append(s))
+
+    # Two 503s then a 200 — one retry, one final success.
+    responses = [
+        httpx.Response(status_code=503, text=""),
+        httpx.Response(status_code=503, text=""),
+        httpx.Response(status_code=200, text="path:hsa01100\tMetabolic pathways\n"),
+    ]
+    rate = 1.0  # explicit, easy to assert against
+    cache_dir = tmp_path / "kegg_cache"
+
+    with patch("httpx.get", side_effect=responses):
+        client = KeggClient(
+            cache_dir=cache_dir,
+            rate_limit_sleep_s=rate,
+            max_retries=3,
+        )
+        body = client.list_pathways(organism="hsa")
+
+    assert body != []  # eventual success
+
+    # Expected sleeps with the fix:
+    #   attempt 0 (503) → backoff rate * 2**0 = 1.0
+    #   attempt 1 (503) → backoff rate * 2**1 = 2.0
+    #   attempt 2 (200) → polite rate-limit  = 1.0  (only on success path)
+    # Sum = 4.0. With the bug, sum was 1.0 + 1.0 + 2.0 + 1.0 + 2.0 + 1.0 = 8.0
+    # (polite sleep fired on each of the three responses, plus the two
+    # backoffs). The fix's total budget must be ≤ 5.0.
+    assert sum(sleeps) <= 5.0, (
+        f"Total sleep budget {sum(sleeps)}s exceeds expected ≤5.0s "
+        f"(see #61). Sleeps observed: {sleeps}"
+    )


### PR DESCRIPTION
## Summary

Two correctness bugs in \`shrine-diet-bioactivity/lightrag/kegg_client.py\`:

- **#60** Cache key \`list_genes_batch_{len}_{first_id}\` collided whenever two batches happened to share length + first element. Now hashes the sorted full ID list (16-hex prefix of SHA-1).
- **#61** Polite \`rate_limit_sleep_s\` fired on every HTTP response — including 5xx retries — doubling the retry wait to \`rate + rate*2^attempt\`. Moved to the success path only.

## Test plan

- [x] Two new tests in \`test_kegg_client.py\` (cache collision + sleep budget); both RED before fix, GREEN after
- [x] Full \`pytest tests/test_kegg_client.py\` — 18/18 pass
- [ ] CI green

Closes #60, #61.