### PR TITLE
fix(entity_schema): tier-4 score floor + empty-pathway warning (#50 #62)

### DIFF
--- a/shrine-diet-bioactivity/lightrag/entity_schema.py
+++ b/shrine-diet-bioactivity/lightrag/entity_schema.py
@@ -232,6 +232,9 @@ RELATIONSHIP_TYPES = {
         # so the edge points at the canonical Disease entity, not a free-text
         # alias. Falls back to symptom_disease_map.disease_name for rows that
         # don't yet have a canonical anchor.
+        # Filter out tier-4 string-match rows (match_score=0.3) — they're
+        # noisy and pollute the recommendation graph (#50). Keep tiers 1-3
+        # (≥0.5) which represent exact / Jaccard / substring matches.
         "query": (
             "SELECT s.name AS src_name, "
             "       COALESCE(d.preferred_name, sdm.disease_name) AS tgt_name, "
@@ -241,6 +244,7 @@ RELATIONSHIP_TYPES = {
             "FROM symptom_disease_map sdm "
             "JOIN symptoms s ON s.id = sdm.symptom_id "
             "LEFT JOIN diseases_canonical d ON d.mesh_id = sdm.mesh_id "
+            "WHERE sdm.match_score >= 0.5 "
             "ORDER BY s.id, sdm.match_score DESC"
         ),
     },

--- a/shrine-diet-bioactivity/lightrag/ingest_direct.py
+++ b/shrine-diet-bioactivity/lightrag/ingest_direct.py
@@ -116,6 +116,15 @@ def extract_duke_relationships(
     cols = [d[0] for d in cur.description]
     rows = [dict(zip(cols, r)) for r in cur.fetchall()]
 
+    if not rows and rel_type == "COMPOUND_IN_PATHWAY":
+        # Lazy-activation observability (#62): the JOIN through
+        # compound_identity is empty until Phase 1 ingest populates it.
+        # Surface this rather than silently producing zero pathway edges.
+        print(
+            "::warning::COMPOUND_IN_PATHWAY returned 0 rows — likely "
+            "compound_identity is empty (Phase 1 ingest not yet run)."
+        )
+
     rels: list[dict] = []
     for row in rows:
         src = str(row.get("src_name", "")).strip()

--- a/shrine-diet-bioactivity/lightrag/tests/test_entity_schema.py
+++ b/shrine-diet-bioactivity/lightrag/tests/test_entity_schema.py
@@ -114,3 +114,72 @@ def test_evidence_for_target_relationship_described():
     assert "Nuclear factor NF-kappa-B p65" in desc
     assert "assay confidence 8" in desc
     assert "year 2018" in desc
+
+
+# ---- Issue #50: MAPS_TO_DISEASE must drop low-confidence string-match rows
+
+
+def test_maps_to_disease_query_filters_low_score_tier4_rows():
+    """The Phase-2 symptom→disease bridge built tier-4 string-match rows at
+    match_score=0.3. Promoting those into LightRAG via MAPS_TO_DISEASE
+    pollutes the recommendation graph with noise. The relationship query
+    must filter to ``match_score >= 0.5`` so tier-4 hits stay out (see #50).
+    """
+    from entity_schema import RELATIONSHIP_TYPES  # noqa: E402
+
+    q = RELATIONSHIP_TYPES["MAPS_TO_DISEASE"]["query"]
+    assert "match_score >= 0.5" in q, (
+        "MAPS_TO_DISEASE query does not filter on match_score — "
+        "tier-4 (0.3) string-match rows leak into the KG (see #50)."
+    )
+
+
+# ---- Issue #62: COMPOUND_IN_PATHWAY zero-row warning
+
+
+def test_compound_in_pathway_warns_on_zero_rows(tmp_path, capsys):
+    """When COMPOUND_IN_PATHWAY's join yields 0 rows (Phase 1 compound_identity
+    not yet populated), extract_duke_relationships must emit a visible
+    warning so the operator notices the missing pathway edges (see #62)."""
+    import sqlite3
+    import sys
+    from pathlib import Path as _P
+
+    sys.path.insert(0, str(_P(__file__).parent.parent))
+    from ingest_direct import extract_duke_relationships  # noqa: E402
+
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE kegg_compound_pathways (
+            kegg_compound_id TEXT,
+            kegg_pathway_id TEXT
+        );
+        CREATE TABLE compound_identity (
+            compound_id INTEGER,
+            kegg_compound_id TEXT
+        );
+        CREATE TABLE compounds (
+            id INTEGER PRIMARY KEY,
+            name TEXT
+        );
+        CREATE TABLE kegg_pathways (
+            id TEXT PRIMARY KEY,
+            name TEXT
+        );
+        """
+    )
+
+    rels = extract_duke_relationships(
+        conn, "COMPOUND_IN_PATHWAY", max_count=None
+    )
+    assert rels == [], "expected zero rows in the empty fixture"
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "COMPOUND_IN_PATHWAY" in combined and (
+        "0 rows" in combined or "no rows" in combined or "empty" in combined.lower()
+    ), (
+        "Expected an operator-visible warning when COMPOUND_IN_PATHWAY "
+        f"returns 0 rows. Captured: out={captured.out!r} err={captured.err!r}"
+    )


### PR DESCRIPTION
## Summary

- **#50** MAPS_TO_DISEASE now filters \`WHERE sdm.match_score >= 0.5\` so tier-4 (0.3) string-match rows stay out of the KG.
- **#62** \`extract_duke_relationships\` emits a \`::warning::\` when COMPOUND_IN_PATHWAY returns 0 rows, surfacing the lazy-activation state instead of silently producing no pathway edges.

## Test plan

- [x] Two new tests in \`test_entity_schema.py\` (SQL contains match_score filter; warning observed on empty COMPOUND_IN_PATHWAY); 8/8 pass
- [ ] CI green
- [ ] No regression in downstream ingest (signal-only)

Closes #50, #62.