### PR TITLE
test(diet-scorer): top-10 PubMed gate + target_id_via_gene contract (#63 #64)

### DIFF
--- a/shrine-diet-bioactivity/lightrag/diet_scorer.py
+++ b/shrine-diet-bioactivity/lightrag/diet_scorer.py
@@ -228,8 +228,11 @@ def score_pathways(
 
     Args:
       target_scores: output of score_targets() (each has target_id + score)
-      kpg_rows: (kegg_pathway_id, pathway_name, target_id_via_gene) tuples
-        — pre-joined from kegg_pathway_genes ↔ targets via gene_symbol.
+      kpg_rows: (kegg_pathway_id, pathway_name, target_id_via_gene) tuples.
+        ``target_id_via_gene`` is **always a ``targets.id`` value** (resolved
+        upstream through ``kegg_pathway_genes`` ↔ ``targets`` via
+        ``gene_symbol``). It is NOT a raw gene_symbol; passing a symbol
+        silently misses the score lookup. See #64.
 
     Returns list sorted by score desc, top TOP_N.
     """

--- a/shrine-diet-bioactivity/lightrag/tests/test_diet_scorer.py
+++ b/shrine-diet-bioactivity/lightrag/tests/test_diet_scorer.py
@@ -254,3 +254,23 @@ def test_evidence_weights_documented():
     # All disease-layer weights below 1.0 (target binding is the gold).
     for k in ("direct_therapeutic", "direct_marker", "inferred_via_gene"):
         assert 0.0 < EVIDENCE_WEIGHTS[k] < 1.0
+
+
+# ---- Issue #64: target_id_via_gene contract ----------------------------
+
+
+def test_score_pathways_target_id_via_gene_is_target_id_not_gene_symbol():
+    """``kpg_rows`` third element MUST be a ``targets.id`` value, not a
+    gene_symbol. The upstream SQL joins ``kegg_pathway_genes`` ↔ ``targets``
+    via gene_symbol, but the column passed to ``score_pathways`` is the
+    resolved target_id. Passing a gene_symbol silently misses the score
+    lookup (regression guard for #64).
+    """
+    target_scores = [{"target_id": "T1", "target": "NFKB1", "score": 100.0}]
+    # Pass the *gene symbol* (NFKB1) where target_id (T1) is expected.
+    kpg_rows = [("hsa04064", "NF-kB", "NFKB1")]
+    out = score_pathways(target_scores, kpg_rows)
+    assert out == [], (
+        "score_pathways looked up gene_symbol as if it were target_id — "
+        "the docstring contract is broken (#64)."
+    )

--- a/shrine-diet-bioactivity/lightrag/tests/test_diet_scorer_live.py
+++ b/shrine-diet-bioactivity/lightrag/tests/test_diet_scorer_live.py
@@ -97,3 +97,26 @@ def test_score_diet_pathway_rollup_works_when_targets_exist(db_conn):
     if result["pathways"]:
         assert "kegg_id" in result["pathways"][0]
         assert "n_targets_hit" in result["pathways"][0]
+
+
+def test_score_diet_top_diseases_each_carry_pubmed_citations(db_conn):
+    """Use-case-A criterion (#63): top-10 ranked diseases should each carry
+    ≥1 PubMed citation so the recommendation is explainable.
+
+    Skips cleanly without the live DB. When the DB is present this gate is
+    stronger than ``test_score_diet_disease_breakdown_has_pubmed_total`` —
+    that older test passes even when ``pubmed_total == 0``.
+    """
+    diet = [("Turmeric", 5), ("Ginger", 10), ("Broccoli", 100)]
+    result = score_diet(diet, conn=db_conn)
+    diseases = result["diseases"][:10]
+    if not diseases:
+        pytest.skip("no diseases scored — KG may lack disease coverage")
+    no_cite = [
+        d for d in diseases
+        if d["evidence_breakdown"]["pubmed_total"] <= 0
+    ]
+    assert not no_cite, (
+        f"top-{len(diseases)} diseases include {len(no_cite)} with 0 "
+        f"PubMed citations — use-case-A (#63) requires ≥1 each."
+    )


### PR DESCRIPTION
Two contract-strengthening fixes for the Phase-5 diet scorer.

- **#63** Adds a stronger gate that every top-10 disease carries ≥1 PubMed citation (use-case-A explainability). The existing test passed at pubmed_total=0.
- **#64** Locks in the contract that score_pathways' kpg_rows[2] is a target_id, not a gene_symbol. Docstring + regression-guard test.

Verified locally: 9/9 pass (live DB present).

Closes #63, #64.