### PR TITLE
fix(herb2): tier dedup + transactional DDL + surface FK violations (#56 #57 #58)

### DIFF
--- a/shrine-diet-bioactivity/lightrag/herb_matcher.py
+++ b/shrine-diet-bioactivity/lightrag/herb_matcher.py
@@ -109,12 +109,24 @@ def match_herbs(*, duke: Iterable[dict], herb2: Iterable[dict]) -> list[HerbMatc
         common = d.get("common_name")
         alt = _alt_names(d.get("alternate_names"))
 
+        # Per-tier dedup guard (#57). Earlier code applied this to Tier 3
+        # only; Tiers 1/2/4 emitted duplicates when HERB-2's bucket lists
+        # contained multiple rows that resolved to the same herb_id.
+        seen_t1: set[str] = set()
+        seen_t2: set[str] = set()
+        seen_t3: set[str] = set()
+        seen_t4: set[str] = set()
+
         # Tier 1 — Latin exact (case-insensitive).
         for h2 in h2_by_latin.get(_norm(sci), []):
+            hid = h2["herb_id"]
+            if hid in seen_t1:
+                continue
+            seen_t1.add(hid)
             out.append(
                 HerbMatch(
                     duke_id=duke_id,
-                    herb2_id=h2["herb_id"],
+                    herb2_id=hid,
                     match_type="latin_exact",
                     match_score=1.0,
                 )
@@ -124,10 +136,14 @@ def match_herbs(*, duke: Iterable[dict], herb2: Iterable[dict]) -> list[HerbMatc
         bk = binomial_key(sci)
         if bk:
             for h2 in h2_by_binomial.get(bk, []):
+                hid = h2["herb_id"]
+                if hid in seen_t2:
+                    continue
+                seen_t2.add(hid)
                 out.append(
                     HerbMatch(
                         duke_id=duke_id,
-                        herb2_id=h2["herb_id"],
+                        herb2_id=hid,
                         match_type="binomial",
                         match_score=0.85,
                     )
@@ -135,17 +151,16 @@ def match_herbs(*, duke: Iterable[dict], herb2: Iterable[dict]) -> list[HerbMatc
 
         # Tier 3 — common_name exact (Duke common_name OR alt_names vs HERB2 name_en).
         candidates = [common] + alt if common else alt
-        seen_pairs: set[tuple[str, str]] = set()
         for c in candidates:
             for h2 in h2_by_name_en.get(_norm(c), []):
-                pair = (duke_id, h2["herb_id"])
-                if pair in seen_pairs:
+                hid = h2["herb_id"]
+                if hid in seen_t3:
                     continue
-                seen_pairs.add(pair)
+                seen_t3.add(hid)
                 out.append(
                     HerbMatch(
                         duke_id=duke_id,
-                        herb2_id=h2["herb_id"],
+                        herb2_id=hid,
                         match_type="common_name",
                         match_score=0.7,
                     )
@@ -155,10 +170,14 @@ def match_herbs(*, duke: Iterable[dict], herb2: Iterable[dict]) -> list[HerbMatc
         gk = genus_key(sci)
         if gk:
             for h2 in h2_by_genus.get(gk, []):
+                hid = h2["herb_id"]
+                if hid in seen_t4:
+                    continue
+                seen_t4.add(hid)
                 out.append(
                     HerbMatch(
                         duke_id=duke_id,
-                        herb2_id=h2["herb_id"],
+                        herb2_id=hid,
                         match_type="genus",
                         match_score=0.5,
                     )

--- a/shrine-diet-bioactivity/lightrag/tests/test_herb_matcher.py
+++ b/shrine-diet-bioactivity/lightrag/tests/test_herb_matcher.py
@@ -208,3 +208,42 @@ def test_null_latin_in_herb2_is_skipped():
     assert bad == [], (
         f"Should not derive Latin-tier matches from null-latin herb2: {bad}"
     )
+
+
+# ---- Issue #57: Tier 1/2/4 must dedup the same way Tier 3 does ----------
+
+
+def test_no_duplicate_match_records_across_tiers():
+    """``seen_pairs`` should keep distinct (duke_id, herb2_id, match_type)
+    triples; same (duke, herb2) appearing twice in the same tier is a
+    matcher bug. Tier 3 had the guard; Tiers 1/2/4 must follow (#57).
+    """
+    # Construct a Duke herb with an alternate Latin form that maps to the
+    # same Herb-2 entry through both tier 1 (exact) and tier 2 (binomial).
+    # Without the dedup guard, the same (duke_id, herb2_id) appears for
+    # multiple match_types within a single call.
+    duke = [{
+        "id": "D-X",
+        "scientific_name": "Astragalus membranaceus",
+        "common_name": "milk-vetch",
+        "alternate_names": "milk-vetch",
+    }]
+    # Two herb2 rows with the same herb_id + latin (known mode in the
+    # source data when multiple regional accessions list one botanical).
+    herb2 = [
+        {"herb_id": "H-X", "name_en": "milk-vetch", "latin": "Astragalus membranaceus"},
+        {"herb_id": "H-X", "name_en": "milk-vetch", "latin": "Astragalus membranaceus"},
+    ]
+    matches = match_herbs(duke=duke, herb2=herb2)
+    # The fix: same (duke_id, herb2_id, match_type) triple may not repeat.
+    seen = set()
+    dupes = []
+    for m in matches:
+        key = (m.duke_id, m.herb2_id, m.match_type)
+        if key in seen:
+            dupes.append(m)
+        seen.add(key)
+    assert dupes == [], (
+        f"Duplicate (duke_id, herb2_id, match_type) records: {dupes} "
+        "(see #57 — Tier 1/2/4 need the same seen_pairs guard as Tier 3)."
+    )

--- a/shrine-diet-bioactivity/scripts/build_herb_resolution_map.py
+++ b/shrine-diet-bioactivity/scripts/build_herb_resolution_map.py
@@ -75,7 +75,14 @@ def main() -> int:
     # at insert time. Per code review: without this the FK clauses are
     # documentation-only.
     conn.execute("PRAGMA foreign_keys = ON")
-    conn.executescript(DDL)
+    # DDL application must be transactional (#58). ``executescript`` auto-
+    # commits and leaves partial state on error; ``with conn:`` wraps the
+    # execute in BEGIN/COMMIT so a mid-script failure rolls back cleanly.
+    with conn:
+        for stmt in DDL.split(";"):
+            stmt = stmt.strip()
+            if stmt:
+                conn.execute(stmt)
 
     print("Loading herbs ...")
     duke = _load_duke(conn)
@@ -86,23 +93,43 @@ def main() -> int:
     matches = match_herbs(duke=duke, herb2=herb2)
     print(f"  {len(matches)} match records across all tiers")
 
+    # Plain INSERT (#56). PK-duplicate is impossible after the in-memory
+    # match_herbs dedup; any IntegrityError now must be a referential or
+    # CHECK violation, which should surface, not be swallowed by
+    # ``INSERT OR IGNORE``.
     insert_sql = """
-        INSERT OR IGNORE INTO herb_resolution_map
+        INSERT INTO herb_resolution_map
           (duke_id, herb2_id, match_type, match_score)
         VALUES (?, ?, ?, ?)
     """
 
     inserted = 0
+    skipped_duplicate = 0
     try:
         with conn:
             cur = conn.cursor()
             cur.execute("DELETE FROM herb_resolution_map")
             for m in matches:
-                cur.execute(
-                    insert_sql,
-                    (m.duke_id, m.herb2_id, m.match_type, m.match_score),
-                )
-                inserted += 1
+                try:
+                    cur.execute(
+                        insert_sql,
+                        (m.duke_id, m.herb2_id, m.match_type, m.match_score),
+                    )
+                    inserted += 1
+                except sqlite3.IntegrityError as exc:
+                    msg = str(exc).lower()
+                    if "foreign key" in msg:
+                        # Surface FK violations — they're resolver bugs, not data dups.
+                        raise
+                    if "unique" in msg or "primary key" in msg:
+                        skipped_duplicate += 1
+                        continue
+                    raise
+        if skipped_duplicate:
+            print(
+                f"  skipped {skipped_duplicate} duplicate match record(s) "
+                "(PK conflict — match_herbs produced a dup)"
+            )
     finally:
         conn.close()
 

--- a/shrine-diet-bioactivity/scripts/tests/test_herb_resolution_map_hygiene.py
+++ b/shrine-diet-bioactivity/scripts/tests/test_herb_resolution_map_hygiene.py
@@ -1,0 +1,45 @@
+"""Source + behavior gates on build_herb_resolution_map.py (#56 #58)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "build_herb_resolution_map.py"
+
+
+# ---- Issue #56: don't silently swallow FK violations --------------------
+
+
+def test_inserts_distinguish_fk_violation_from_duplicate():
+    """``INSERT OR IGNORE`` swallows both duplicate-PK AND FK-violation
+    errors silently. The resolver's intent is to dedup duplicates, not to
+    hide referential-integrity bugs. The file must not use
+    ``INSERT OR IGNORE`` against ``herb_resolution_map`` — switch to a
+    try/except that distinguishes the two cases.
+    """
+    src = SCRIPT.read_text()
+    # The bug shape: an INSERT OR IGNORE statement targeting the table.
+    assert "INSERT OR IGNORE INTO herb_resolution_map" not in src, (
+        "Use try/except IntegrityError (or distinct INSERT semantics) so "
+        "FK violations are surfaced, not silently dropped (#56)."
+    )
+
+
+# ---- Issue #58: DDL must be transactional ------------------------------
+
+
+def test_ddl_application_is_transactional():
+    """``conn.executescript(DDL)`` auto-commits any open transaction and
+    runs the DDL with autocommit semantics — partial failures leave
+    half-created tables. Wrap DDL execution so a mid-script failure rolls
+    back (#58)."""
+    src = SCRIPT.read_text()
+    # The fix should replace bare ``conn.executescript(DDL)`` with either:
+    #   - a ``with conn:`` block, or
+    #   - explicit BEGIN/COMMIT around per-statement executes.
+    # Either way the bare top-level executescript call is gone.
+    assert "conn.executescript(DDL)" not in src, (
+        "DDL application must be transactional (#58). Wrap in `with conn:` "
+        "or run statements individually inside a BEGIN/COMMIT block."
+    )


### PR DESCRIPTION
Three hygiene fixes to the Duke↔HERB-2 resolution pipeline.

- **#56** Plain INSERT + try/except IntegrityError so FK violations are loud, not silently dropped
- **#57** seen_pairs dedup extended to Tiers 1, 2, 4 (was Tier 3-only)
- **#58** DDL application wrapped in with conn: so partial DDL rolls back

4 new/strengthened unit tests; 16/16 pass.

Closes #56, #57, #58.