### PR TITLE
fix(ctd): surface stream errors + WS-quoted fields + CRLF contract (#53 #54 #55)

### DIFF
--- a/shrine-diet-bioactivity/scripts/_csv-parse.ts
+++ b/shrine-diet-bioactivity/scripts/_csv-parse.ts
@@ -42,8 +42,12 @@ export function parseCsvLine(line: string): string[] {
       continue;
     }
 
-    if (ch === '"' && buf.length === 0) {
-      // Field-opening quote (only at the start of a field).
+    if (ch === '"' && buf.trim() === '') {
+      // Field-opening quote — at the start of a field, ignoring any
+      // leading whitespace (#55). Some CTD producers pad fields after
+      // the comma; before this change the leading space prevented the
+      // quote from being recognized, and the comma inside the quoted
+      // disease name leaked through as a field separator.
       inQuotes = true;
       i += 1;
       continue;

--- a/shrine-diet-bioactivity/scripts/load-ctd.ts
+++ b/shrine-diet-bioactivity/scripts/load-ctd.ts
@@ -65,9 +65,25 @@ async function streamGzipCsv(
 
   const gunzip = zlib.createGunzip();
   const input = fs.createReadStream(filePath);
+
+  // Surface stream errors loudly (#53). Without these handlers, a missing
+  // file or corrupt .gz would emit an unhandled 'error' event — readline
+  // would end the for-await silently and the loader would report 0 rows
+  // as if the file were empty.
+  let streamError: Error | null = null;
+  input.on('error', (err) => {
+    streamError = new Error(`load-ctd: read failed for ${filePath}: ${err.message}`);
+  });
+  gunzip.on('error', (err) => {
+    streamError = new Error(`load-ctd: gunzip failed for ${filePath}: ${err.message}`);
+  });
+
   const rl = readline.createInterface({ input: input.pipe(gunzip) });
 
   for await (const rawLine of rl) {
+    if (streamError) {
+      throw streamError;
+    }
     // Defense-in-depth against CRLF: CTD currently ships LF-only files
     // (verified May 2026), but readline does NOT strip a trailing \r if
     // the upstream ever switches to Windows endings. Strip it here so
@@ -95,6 +111,12 @@ async function streamGzipCsv(
     } else {
       stats.skipped++;
     }
+  }
+
+  // Also check after the loop in case the error fires after the last
+  // successful read (e.g., a gunzip trailer mismatch on the final chunk).
+  if (streamError) {
+    throw streamError;
   }
 
   return stats;

--- a/shrine-diet-bioactivity/src/__tests__/csv-parse.test.ts
+++ b/shrine-diet-bioactivity/src/__tests__/csv-parse.test.ts
@@ -88,3 +88,41 @@ describe('parseCsvLine', () => {
     expect(parseCsvLine('a,b,c\r')).toEqual(['a', 'b', 'c\r']);
   });
 });
+
+// ---- Issue #55: leading-whitespace quoted field ---------------------------
+
+describe('parseCsvLine — issue #55 (leading whitespace + quoted field)', () => {
+  it('treats a quote opening as field-opener even after leading whitespace', () => {
+    // CTD producers sometimes pad fields: `a, "Lymphoma, Mantle-Cell",b`.
+    // Before the fix, the leading space puts `buf=" "` so the `"` is not
+    // treated as field-opening — the comma inside the quoted name then
+    // gets parsed as a field separator, shifting every later column.
+    expect(parseCsvLine('a, "Lymphoma, Mantle-Cell",b')).toEqual([
+      'a',
+      ' Lymphoma, Mantle-Cell',
+      'b',
+    ]);
+  });
+});
+
+// ---- Issue #54: CRLF cross-layer contract --------------------------------
+
+describe('CRLF cross-layer contract (#54)', () => {
+  // The contract is: load-ctd.streamGzipCsv strips a trailing \r before
+  // calling parseCsvLine, so the last field never carries a stray \r.
+  // The parser itself is line-ending agnostic; this test pins both halves.
+
+  it('parser passes-through a stray \\r — caller must strip', () => {
+    expect(parseCsvLine('a,b,c\r')).toEqual(['a', 'b', 'c\r']);
+  });
+
+  it('the caller-side strip (rawLine.endsWith) handles CRLF', () => {
+    const rawLine = 'a,b,c\r';
+    const stripped = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    expect(parseCsvLine(stripped)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('LF-only lines (current CTD shape) parse cleanly', () => {
+    expect(parseCsvLine('a,b,c')).toEqual(['a', 'b', 'c']);
+  });
+});


### PR DESCRIPTION
Three CTD-loader hygiene fixes batched.

- **#53** load-ctd.streamGzipCsv now attaches `.on('error', ...)` to both `createReadStream` and `createGunzip` and re-throws with file context.
- **#54** CRLF cross-layer contract tests pin both halves: parser is line-ending agnostic; caller strips `\r`.
- **#55** `parseCsvLine` recognizes a field-opening quote even after leading whitespace (`buf.trim() === ''`).

Vitest 98/98; tsc clean.

Closes #53, #54, #55.