### PR TITLE
fix(herb-matcher): hybrid binomial + genus cap (#24[7] #24[8])

### DIFF
--- a/shrine-diet-bioactivity/lightrag/herb_matcher.py
+++ b/shrine-diet-bioactivity/lightrag/herb_matcher.py
@@ -33,17 +33,28 @@ def _norm(s: Optional[str]) -> str:
 
 
 def binomial_key(latin: Optional[str]) -> Optional[str]:
-    """First two whitespace-separated tokens of a Latin name, lowercased.
+    """First two meaningful whitespace-separated tokens of a Latin name,
+    lowercased.
+
+    Drops botanical hybrid marks (``×``) and authority tokens that begin
+    with an apostrophe (e.g. cultivar tags like ``'Hidcote'``) before
+    picking the first two tokens (#24[8]). Without this, ``Mentha ×
+    piperita`` produces ``mentha ×`` which never matches Duke's plain
+    binomials.
 
     Trims subspecies / variety / authority annotations:
         "Achillea millefolium subsp. lanulosa" → "achillea millefolium"
+        "Mentha × piperita"                    → "mentha piperita"
 
-    Returns None if the input has fewer than two tokens.
+    Returns None if the input has fewer than two meaningful tokens.
     """
     n = _norm(latin)
     if not n:
         return None
-    parts = n.split()
+    parts = [
+        p for p in n.split()
+        if p != "×" and not p.startswith("'")
+    ]
     if len(parts) < 2:
         return None
     return f"{parts[0]} {parts[1]}"
@@ -70,11 +81,21 @@ def _alt_names(raw: Optional[str]) -> list[str]:
     return [str(s) for s in parsed if s]
 
 
-def match_herbs(*, duke: Iterable[dict], herb2: Iterable[dict]) -> list[HerbMatch]:
+def match_herbs(
+    *,
+    duke: Iterable[dict],
+    herb2: Iterable[dict],
+    max_genus_matches_per_duke_herb: Optional[int] = None,
+) -> list[HerbMatch]:
     """Resolve Duke herbs to HERB 2.0 herbs across four match tiers.
 
     Each tier emits its own record per (duke_id, herb2_id) pair — a single
     Duke herb may appear under multiple tiers for the same target.
+
+    ``max_genus_matches_per_duke_herb`` (default None = no cap, #24[7])
+    bounds Tier-4 records per Duke herb. Widespread genera (Astragalus,
+    Carex, Senecio) otherwise produce hundreds of low-confidence rows per
+    Duke entry. Has no effect on Tiers 1-3.
     """
     duke_list = list(duke)
     herb2_list = list(herb2)
@@ -169,7 +190,13 @@ def match_herbs(*, duke: Iterable[dict], herb2: Iterable[dict]) -> list[HerbMatc
         # Tier 4 — genus (first token of Latin). Lower confidence; broad recall.
         gk = genus_key(sci)
         if gk:
+            genus_emitted = 0
             for h2 in h2_by_genus.get(gk, []):
+                if (
+                    max_genus_matches_per_duke_herb is not None
+                    and genus_emitted >= max_genus_matches_per_duke_herb
+                ):
+                    break
                 hid = h2["herb_id"]
                 if hid in seen_t4:
                     continue
@@ -182,5 +209,6 @@ def match_herbs(*, duke: Iterable[dict], herb2: Iterable[dict]) -> list[HerbMatc
                         match_score=0.5,
                     )
                 )
+                genus_emitted += 1
 
     return out

--- a/shrine-diet-bioactivity/lightrag/tests/test_herb_matcher.py
+++ b/shrine-diet-bioactivity/lightrag/tests/test_herb_matcher.py
@@ -218,10 +218,6 @@ def test_no_duplicate_match_records_across_tiers():
     triples; same (duke, herb2) appearing twice in the same tier is a
     matcher bug. Tier 3 had the guard; Tiers 1/2/4 must follow (#57).
     """
-    # Construct a Duke herb with an alternate Latin form that maps to the
-    # same Herb-2 entry through both tier 1 (exact) and tier 2 (binomial).
-    # Without the dedup guard, the same (duke_id, herb2_id) appears for
-    # multiple match_types within a single call.
     duke = [{
         "id": "D-X",
         "scientific_name": "Astragalus membranaceus",
@@ -235,7 +231,6 @@ def test_no_duplicate_match_records_across_tiers():
         {"herb_id": "H-X", "name_en": "milk-vetch", "latin": "Astragalus membranaceus"},
     ]
     matches = match_herbs(duke=duke, herb2=herb2)
-    # The fix: same (duke_id, herb2_id, match_type) triple may not repeat.
     seen = set()
     dupes = []
     for m in matches:
@@ -247,3 +242,44 @@ def test_no_duplicate_match_records_across_tiers():
         f"Duplicate (duke_id, herb2_id, match_type) records: {dupes} "
         "(see #57 — Tier 1/2/4 need the same seen_pairs guard as Tier 3)."
     )
+
+
+# ---- Issue #24[7]: per-Duke genus cap -----------------------------------
+
+
+def test_match_herbs_caps_genus_tier_per_duke_herb():
+    """For widespread genera (Astragalus ~3K species, Carex ~2K, Senecio
+    ~1.25K), each Duke herb can produce hundreds of genus-tier rows. The
+    matcher accepts an optional ``max_genus_matches_per_duke_herb`` (#24[7])
+    that caps Tier-4 records per Duke herb without affecting Tiers 1-3.
+    """
+    duke = [{"id": "D-A", "scientific_name": "Astragalus membranaceus"}]
+    herb2 = [
+        {"herb_id": f"H-{i}", "name_en": f"sp{i}", "latin": f"Astragalus sp{i}"}
+        for i in range(120)
+    ]
+    matches = match_herbs(
+        duke=duke, herb2=herb2, max_genus_matches_per_duke_herb=50
+    )
+    genus_count = sum(1 for m in matches if m.match_type == "genus")
+    assert genus_count <= 50, (
+        f"genus cap not enforced: produced {genus_count} > 50 (#24[7])"
+    )
+
+
+# ---- Issue #24[8]: hybrid mark in binomial_key -------------------------
+
+
+def test_binomial_key_drops_hybrid_mark():
+    """``Mentha × piperita`` → binomial key ``mentha piperita`` (drop the
+    botanical hybrid mark ``×``). Before the fix the key was ``mentha ×``
+    which never matched Duke's plain binomials (#24[8])."""
+    assert binomial_key("Mentha × piperita") == "mentha piperita"
+    assert binomial_key("Citrus × paradisi") == "citrus paradisi"
+
+
+def test_binomial_key_drops_authority_apostrophe():
+    """Tokens beginning with ``'`` are authority markers (e.g.
+    ``'Lavendula 'Hidcote''``) and should be dropped (#24[8])."""
+    # Multi-token authority: 'Hidcote' is a cultivar tag.
+    assert binomial_key("Lavandula 'Hidcote' angustifolia") == "lavandula angustifolia"


### PR DESCRIPTION
Two herb_matcher polish items from #24 (Phase 2 review).

- **#24[7]** `max_genus_matches_per_duke_herb` optional parameter caps Tier-4 records per Duke herb (Astragalus etc.).
- **#24[8]** `binomial_key` drops `×` and apostrophe-prefixed tokens — `Mentha × piperita` now produces `mentha piperita`.

3 new tests; 16/16 pass.