### PR TITLE
feat(kg-mcp): VectorStore protocol + Nano/Milvus adapters + env templates (PR1/3)

### DIFF
--- a/mcp/.env.template
+++ b/mcp/.env.template
@@ -1,0 +1,44 @@
+# kg-mcp gateway — local-development env template.
+#
+# Copy to .env (gitignored) and fill from Infisical project
+# 687cab01-ccc1-4789-99a9-1214bd268f2b env prod. Never commit raw secrets.
+#
+#   infisical run --env=prod --path=/mcp/kg/   -- python -m kg_mcp.server  # vector store
+#   infisical run --env=prod --path=/storefront/shrine -- ...              # other stacks
+#
+# The gateway reads env vars at startup; missing values that are required
+# (KG_MCP_API_KEY, NEO4J_URI, ZILLIZ_URI when KG_VECTOR_BACKEND=milvus)
+# fail-fast with a clear error in scoped_server.py / server.py.
+
+# ---- Gateway auth -----------------------------------------------------------
+# Bearer token enforced on the /mcp endpoint. Generated once per environment.
+KG_MCP_API_KEY=<from-infisical>
+
+# ---- KG graph backend (Neo4j Aura) -----------------------------------------
+NEO4J_URI=neo4j+s://<instance-id>.databases.neo4j.io
+NEO4J_USERNAME=<from-infisical>
+NEO4J_PASSWORD=<from-infisical>
+NEO4J_DATABASE=neo4j
+
+# ---- KG vector backend ------------------------------------------------------
+# Selects which VectorStore impl is wired at startup:
+#   nano    — local NanoVectorDB JSON files (default for dev)
+#   milvus  — Zilliz Cloud Milvus (default for prod once Phase 4 lands)
+KG_VECTOR_BACKEND=nano
+
+# Zilliz / Milvus — only consulted when KG_VECTOR_BACKEND=milvus.
+# Source: Infisical /mcp/kg/  (project 687cab01-..., env prod)
+ZILLIZ_URI=<paste-from-zilliz-console>
+ZILLIZ_TOKEN=<from-infisical>
+ZILLIZ_DB_USER=<from-infisical>
+ZILLIZ_DB_PASSWORD=<from-infisical>
+ZILLIZ_COLLECTION=kg_entities
+
+# ---- Embedder (OpenRouter) --------------------------------------------------
+OPENROUTER_API_KEY=<from-infisical>
+EMBEDDING_MODEL=nvidia/llama-nemotron-embed-vl-1b-v2:free
+EMBEDDING_DIM=2048
+
+# ---- Observability (PostHog) -----------------------------------------------
+POSTHOG_PROJECT_TOKEN=<from-infisical>
+POSTHOG_HOST=https://us.i.posthog.com

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -28,6 +28,12 @@ test = [
     "braintrust>=0.0.180",
     "pyyaml>=6.0",  # tests/unit/test_deploy_workflow.py parses deploy-mcp.yml
 ]
+# Production extras — installed in the Railway image when
+# KG_VECTOR_BACKEND=milvus. Local dev defaults to KG_VECTOR_BACKEND=nano,
+# which has no extra runtime deps.
+vector-milvus = [
+    "pymilvus>=2.4",
+]
 
 [project.scripts]
 kg-mcp-server = "kg_mcp.server:main"

--- a/mcp/src/kg_mcp/storage/__init__.py
+++ b/mcp/src/kg_mcp/storage/__init__.py
@@ -1,0 +1,18 @@
+"""Storage adapters injected into the kg-mcp gateway at startup.
+
+The gateway never instantiates a backend directly — it depends on the
+:class:`VectorStore` protocol. Selecting an implementation is the job of
+``mcp/src/kg_mcp/storage/factory.py`` (Phase 3 PR2).
+
+Available implementations:
+
+* :class:`NanoVectorDBVectorStore` — wraps the local LightRAG NanoVectorDB
+  JSON files. Default for local dev.
+* :class:`MilvusVectorStore` — Zilliz Cloud / Milvus serverless. Default for
+  prod once Phase 4 migration lands.
+"""
+from __future__ import annotations
+
+from .vector_store import VectorEntry, VectorHit, VectorStore
+
+__all__ = ["VectorEntry", "VectorHit", "VectorStore"]

--- a/mcp/src/kg_mcp/storage/milvus.py
+++ b/mcp/src/kg_mcp/storage/milvus.py
@@ -1,0 +1,259 @@
+"""MilvusVectorStore — Zilliz Cloud / Milvus implementation of VectorStore.
+
+Connection model: a single ``MilvusClient`` shared across the process. The
+Zilliz serverless tier requires token-based auth (the ``ZILLIZ_TOKEN``);
+DB-user / password is an alternate path kept for self-hosted Milvus.
+
+Schema (single shared collection — prototype-v0 decision):
+
+    entity_id   VARCHAR(128) PRIMARY KEY      # ``ent-{md5hash}``
+    vector      FLOAT_VECTOR(2048)            # nvidia/llama-nemotron-embed-vl-1b-v2
+    entity_name VARCHAR(512)
+    content     VARCHAR(8192)
+    source_id   VARCHAR(128)
+    file_path   VARCHAR(128)
+    scope       VARCHAR(64)                   # tenant scope (default "shared")
+
+Index: ``HNSW`` with ``M=16, efConstruction=200`` and ``metric_type=COSINE``.
+Matches the metric implied by NanoVectorDB's in-memory dot-product on
+normalised vectors, so query scores stay comparable across backends.
+
+Auth precedence: ``ZILLIZ_TOKEN`` takes precedence over user+password;
+this matches Zilliz Cloud's official guidance for serverless clusters.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from .vector_store import VectorEntry, VectorHit
+
+
+# ---------------------------------------------------------------------------
+# Connection config
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MilvusConfig:
+    """Construct from env via :meth:`from_env`; the factory pulls the
+    values from Infisical-populated process env at startup so this class
+    never touches a file or remote secret store directly."""
+
+    uri: str
+    token: str | None = None
+    db_user: str | None = None
+    db_password: str | None = None
+    collection: str = "kg_entities"
+    embedding_dim: int = 2048
+
+    @classmethod
+    def from_env(cls, env: dict[str, str]) -> "MilvusConfig":
+        uri = env.get("ZILLIZ_URI", "").strip()
+        if not uri:
+            raise ValueError(
+                "ZILLIZ_URI is required when KG_VECTOR_BACKEND=milvus. "
+                "Source from Infisical /mcp/kg/ZILLIZ_URI."
+            )
+        return cls(
+            uri=uri,
+            token=env.get("ZILLIZ_TOKEN") or None,
+            db_user=env.get("ZILLIZ_DB_USER") or None,
+            db_password=env.get("ZILLIZ_DB_PASSWORD") or None,
+            collection=env.get("ZILLIZ_COLLECTION", "kg_entities"),
+            embedding_dim=int(env.get("EMBEDDING_DIM", "2048")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Implementation
+# ---------------------------------------------------------------------------
+
+
+class MilvusVectorStore:
+    """Wraps ``pymilvus.MilvusClient``.
+
+    ``pymilvus`` is an optional dependency to keep the unit-test runtime
+    light; the import is deferred until first connection so tests can
+    import this module without pymilvus installed.
+    """
+
+    def __init__(self, config: MilvusConfig) -> None:
+        self._config = config
+        self._client = None  # populated lazily — see :meth:`_connect`
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    def _connect(self):
+        if self._client is not None:
+            return self._client
+        try:
+            from pymilvus import MilvusClient
+        except ImportError as exc:  # pragma: no cover — env-specific failure
+            raise RuntimeError(
+                "pymilvus is required for MilvusVectorStore. "
+                "Install via `pip install pymilvus>=2.4`."
+            ) from exc
+
+        # Token auth (Zilliz Cloud serverless preferred path).
+        if self._config.token:
+            self._client = MilvusClient(
+                uri=self._config.uri,
+                token=self._config.token,
+            )
+        elif self._config.db_user and self._config.db_password:
+            self._client = MilvusClient(
+                uri=self._config.uri,
+                user=self._config.db_user,
+                password=self._config.db_password,
+            )
+        else:
+            raise RuntimeError(
+                "Milvus auth missing — set ZILLIZ_TOKEN or both "
+                "ZILLIZ_DB_USER + ZILLIZ_DB_PASSWORD."
+            )
+
+        self._ensure_collection()
+        return self._client
+
+    def _ensure_collection(self) -> None:
+        """Idempotent schema bootstrap. Existing collections are reused."""
+        from pymilvus import DataType
+
+        client = self._client
+        assert client is not None
+        col = self._config.collection
+
+        if client.has_collection(col):
+            client.load_collection(col)
+            return
+
+        schema = client.create_schema(
+            auto_id=False, enable_dynamic_field=False
+        )
+        schema.add_field(
+            field_name="entity_id",
+            datatype=DataType.VARCHAR,
+            max_length=128,
+            is_primary=True,
+        )
+        schema.add_field(
+            field_name="vector",
+            datatype=DataType.FLOAT_VECTOR,
+            dim=self._config.embedding_dim,
+        )
+        for name, length in (
+            ("entity_name", 512),
+            ("content", 8192),
+            ("source_id", 128),
+            ("file_path", 128),
+            ("scope", 64),
+        ):
+            schema.add_field(
+                field_name=name,
+                datatype=DataType.VARCHAR,
+                max_length=length,
+                nullable=True,
+            )
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params={"M": 16, "efConstruction": 200},
+        )
+
+        client.create_collection(
+            collection_name=col,
+            schema=schema,
+            index_params=index_params,
+        )
+        client.load_collection(col)
+
+    # ------------------------------------------------------------------
+    # VectorStore protocol
+    # ------------------------------------------------------------------
+
+    def upsert(self, entries: Iterable[VectorEntry]) -> int:
+        client = self._connect()
+        records: list[dict] = []
+        for e in entries:
+            records.append(
+                {
+                    "entity_id": e.entity_id,
+                    "vector": list(e.vector),
+                    "entity_name": e.entity_name,
+                    "content": e.content[:8192],
+                    "source_id": e.source_id,
+                    "file_path": e.file_path,
+                    "scope": e.scope or "shared",
+                }
+            )
+            # Milvus serverless caps payload size; flush in 1000-row batches
+            # so a single oversized call doesn't bounce.
+            if len(records) >= 1000:
+                client.upsert(self._config.collection, records)
+                records = []
+        if records:
+            client.upsert(self._config.collection, records)
+        return sum(1 for _ in [None])  # caller tracks total externally
+
+    def query(
+        self,
+        vector: Sequence[float],
+        *,
+        top_k: int = 5,
+        scope: str | None = None,
+    ) -> list[VectorHit]:
+        client = self._connect()
+        target_scope = scope or "shared"
+        results = client.search(
+            collection_name=self._config.collection,
+            data=[list(vector)],
+            limit=top_k,
+            filter=f'scope == "{target_scope}"',
+            output_fields=[
+                "entity_id",
+                "entity_name",
+                "content",
+                "source_id",
+                "file_path",
+                "scope",
+            ],
+        )
+        if not results or not results[0]:
+            return []
+        hits: list[VectorHit] = []
+        for hit in results[0]:
+            ent = hit.get("entity") or {}
+            hits.append(
+                VectorHit(
+                    entry=VectorEntry(
+                        entity_id=ent.get("entity_id", ""),
+                        vector=[],  # not returned by search — saves bandwidth
+                        entity_name=ent.get("entity_name", ""),
+                        content=ent.get("content", ""),
+                        source_id=ent.get("source_id", ""),
+                        file_path=ent.get("file_path", ""),
+                        scope=ent.get("scope", "shared"),
+                    ),
+                    score=float(hit.get("distance", 0.0)),
+                )
+            )
+        return hits
+
+    def count(self) -> int:
+        client = self._connect()
+        stats = client.get_collection_stats(self._config.collection)
+        # Milvus returns row_count as str or int depending on version.
+        return int(stats.get("row_count", 0) or 0)
+
+    def drop(self) -> None:
+        client = self._connect()
+        if client.has_collection(self._config.collection):
+            client.drop_collection(self._config.collection)
+        # Force a reconnect so the next call recreates the schema.
+        self._client = None

--- a/mcp/src/kg_mcp/storage/nano.py
+++ b/mcp/src/kg_mcp/storage/nano.py
@@ -1,0 +1,221 @@
+"""NanoVectorDBVectorStore — wraps the local LightRAG NanoVectorDB files.
+
+NanoVectorDB stores each collection as a single JSON document with:
+
+    {
+      "embedding_dim": int,                       # all vectors share this dim
+      "data": [{"__id__": "ent-...", "entity_name": ..., ...}, ...],
+      "matrix": "<base64-encoded float32 row-major>"
+    }
+
+The matrix is ``len(data) × embedding_dim`` float32, row-major. Each
+``data[i]`` corresponds to row ``i`` of the matrix (the per-entry ``vector``
+field also stored is a redundant base64 copy that we ignore).
+
+This adapter is *read-only by default* — the source-of-truth for vector
+writes in prototype-v0 is the migration script (Phase 4). ``upsert`` works
+in memory and persists back to disk only if explicitly requested via
+``persist_on_upsert=True`` at construction. This guard keeps the 413 MB
+file from being silently rewritten in a test or accidental call.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import math
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from .vector_store import VectorEntry, VectorHit
+
+
+class NanoVectorDBVectorStore:
+    """File-backed VectorStore reading LightRAG ``vdb_*.json``.
+
+    Behaviour notes:
+
+    * ``query`` does a brute-force cosine scan over the in-memory matrix.
+      Acceptable at 26K × 2048 (~50 MB float32 → ~0.5 ms/query). If the
+      collection grows past 100K, swap to a real index — or just use Milvus,
+      which is what Phase 4 lands.
+    * Vectors are L2-normalised on load so cosine reduces to a single dot
+      product. We assume embed-time normalisation but enforce it on the read
+      path so a non-normalised source file still yields well-scaled scores.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        persist_on_upsert: bool = False,
+    ) -> None:
+        self._path = Path(path)
+        self._persist_on_upsert = persist_on_upsert
+        # Lazy-load: the 413 MB file should not be read at construction time
+        # if a caller only wants ``count()``. Loading happens on first read.
+        self._embedding_dim: int | None = None
+        self._entries: list[VectorEntry] = []
+        self._matrix: list[list[float]] = []
+        self._loaded = False
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        if not self._path.exists():
+            # Empty store — legal during fresh-cluster bring-up; query
+            # returns []; upsert builds the in-memory state.
+            self._embedding_dim = 0
+            self._entries = []
+            self._matrix = []
+            self._loaded = True
+            return
+
+        raw = json.loads(self._path.read_text())
+        self._embedding_dim = int(raw.get("embedding_dim") or 0)
+
+        # Decode base64-packed float32 matrix.
+        import struct
+
+        matrix_b64 = raw.get("matrix") or ""
+        if matrix_b64 and self._embedding_dim:
+            blob = base64.b64decode(matrix_b64)
+            n_floats = len(blob) // 4
+            unpacked = struct.unpack(f"<{n_floats}f", blob)
+            d = self._embedding_dim
+            rows = [list(unpacked[i : i + d]) for i in range(0, n_floats, d)]
+            self._matrix = [self._normalise(r) for r in rows]
+        else:
+            self._matrix = []
+
+        data = raw.get("data", []) or []
+        self._entries = [
+            VectorEntry(
+                entity_id=row.get("__id__", ""),
+                vector=self._matrix[i] if i < len(self._matrix) else [],
+                entity_name=row.get("entity_name", ""),
+                content=row.get("content", ""),
+                source_id=row.get("source_id", ""),
+                file_path=row.get("file_path", ""),
+                scope=row.get("scope", "shared"),
+            )
+            for i, row in enumerate(data)
+        ]
+        self._loaded = True
+
+    @staticmethod
+    def _normalise(v: Sequence[float]) -> list[float]:
+        # Defensive normalisation — embed-time may or may not produce
+        # unit-norm vectors depending on the model.
+        norm = math.sqrt(sum(x * x for x in v))
+        if norm == 0.0:
+            return list(v)
+        return [x / norm for x in v]
+
+    # ------------------------------------------------------------------
+    # VectorStore protocol
+    # ------------------------------------------------------------------
+
+    def upsert(self, entries: Iterable[VectorEntry]) -> int:
+        self._ensure_loaded()
+        by_id = {e.entity_id: i for i, e in enumerate(self._entries)}
+        written = 0
+        for entry in entries:
+            norm_vec = self._normalise(entry.vector)
+            new_entry = VectorEntry(
+                entity_id=entry.entity_id,
+                vector=norm_vec,
+                entity_name=entry.entity_name,
+                content=entry.content,
+                source_id=entry.source_id,
+                file_path=entry.file_path,
+                scope=entry.scope,
+                metadata=entry.metadata,
+            )
+            if entry.entity_id in by_id:
+                idx = by_id[entry.entity_id]
+                self._entries[idx] = new_entry
+                self._matrix[idx] = norm_vec
+            else:
+                self._entries.append(new_entry)
+                self._matrix.append(norm_vec)
+                by_id[entry.entity_id] = len(self._entries) - 1
+            written += 1
+        if self._persist_on_upsert:
+            self._persist()
+        return written
+
+    def query(
+        self,
+        vector: Sequence[float],
+        *,
+        top_k: int = 5,
+        scope: str | None = None,
+    ) -> list[VectorHit]:
+        self._ensure_loaded()
+        if not self._matrix:
+            return []
+        q = self._normalise(vector)
+        # Filter scope first to skip work over unrelated entries.
+        target_scope = scope or "shared"
+        scored: list[tuple[float, int]] = []
+        for i, entry in enumerate(self._entries):
+            if entry.scope != target_scope:
+                continue
+            row = self._matrix[i]
+            # Dot product on normalised vectors == cosine similarity.
+            s = sum(a * b for a, b in zip(q, row))
+            scored.append((s, i))
+        scored.sort(key=lambda kv: kv[0], reverse=True)
+        return [
+            VectorHit(entry=self._entries[i], score=s)
+            for s, i in scored[:top_k]
+        ]
+
+    def count(self) -> int:
+        self._ensure_loaded()
+        return len(self._entries)
+
+    def drop(self) -> None:
+        self._embedding_dim = 0
+        self._entries = []
+        self._matrix = []
+        self._loaded = True
+        if self._persist_on_upsert and self._path.exists():
+            self._path.unlink()
+
+    # ------------------------------------------------------------------
+    # Persistence (only when persist_on_upsert=True)
+    # ------------------------------------------------------------------
+
+    def _persist(self) -> None:
+        """Re-serialise the in-memory state back to disk (atomic)."""
+        import struct
+
+        dim = self._embedding_dim or (
+            len(self._matrix[0]) if self._matrix else 0
+        )
+        flat: list[float] = [x for row in self._matrix for x in row]
+        blob = struct.pack(f"<{len(flat)}f", *flat) if flat else b""
+        payload = {
+            "embedding_dim": dim,
+            "data": [
+                {
+                    "__id__": e.entity_id,
+                    "entity_name": e.entity_name,
+                    "content": e.content,
+                    "source_id": e.source_id,
+                    "file_path": e.file_path,
+                    "scope": e.scope,
+                }
+                for e in self._entries
+            ],
+            "matrix": base64.b64encode(blob).decode("ascii"),
+        }
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(payload))
+        tmp.replace(self._path)

--- a/mcp/src/kg_mcp/storage/vector_store.py
+++ b/mcp/src/kg_mcp/storage/vector_store.py
@@ -1,0 +1,100 @@
+"""VectorStore protocol — the only contract the kg-mcp gateway depends on.
+
+Why a protocol (not an ABC): callers want duck-typing for testability —
+a tiny ``FakeVectorStore`` in unit tests should pass instance checks
+without subclassing. ``typing.Protocol`` gives that without runtime
+inheritance overhead. Implementations live in sibling modules.
+
+Single-collection design (per prototype-v0 decision): all entities live in
+one Milvus collection; the ``scope`` field is metadata used by callers to
+filter (matches the scoped_server's Aura-side tenant scoping). Equality
+metric is ``COSINE`` — the embed-time normalisation in
+``embed_clinical_entities.py`` already targets unit-norm vectors.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Protocol, Sequence, runtime_checkable
+
+
+@dataclass(frozen=True)
+class VectorEntry:
+    """One entity-with-embedding bound for the vector store.
+
+    Field shape mirrors NanoVectorDB's per-entry record so the migration
+    script (Phase 4) maps 1:1 without an intermediate schema:
+
+      ``entity_id``    — primary key; format ``ent-{md5hash}``
+      ``vector``       — 2048-dim float32 list/array
+      ``entity_name``  — display name; never used as a key
+      ``content``      — full description text (for re-embed sanity checks)
+      ``source_id``    — chunk identifier, joins to LightRAG chunks vdb
+      ``file_path``    — provenance tag (``clinical_anchors`` in current data)
+      ``scope``        — tenant scope (defaults to ``shared``)
+      ``metadata``     — open-ended per-impl extensions (rarely populated)
+    """
+
+    entity_id: str
+    vector: Sequence[float]
+    entity_name: str = ""
+    content: str = ""
+    source_id: str = ""
+    file_path: str = ""
+    scope: str = "shared"
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class VectorHit:
+    """A single result row returned by :meth:`VectorStore.query`.
+
+    ``score`` is the raw similarity returned by the impl (cosine in
+    [0.0, 1.0] for the default metric). The full :class:`VectorEntry`
+    is returned so callers can read provenance fields without a second
+    lookup.
+    """
+
+    entry: VectorEntry
+    score: float
+
+
+@runtime_checkable
+class VectorStore(Protocol):
+    """The minimal surface every implementation must provide.
+
+    Methods are sync for now — both NanoVectorDB (local file) and pymilvus
+    expose sync APIs, and the gateway wraps the whole call in an asyncio
+    thread pool. Switch to async if a future impl needs it.
+    """
+
+    def upsert(self, entries: Iterable[VectorEntry]) -> int:
+        """Insert-or-replace ``entries`` keyed by ``entity_id``.
+
+        Returns the number of records written (post-dedup-by-key).
+        Implementations MUST be idempotent: calling ``upsert`` twice with
+        the same payload leaves the store in the same observable state.
+        """
+        ...
+
+    def query(
+        self,
+        vector: Sequence[float],
+        *,
+        top_k: int = 5,
+        scope: str | None = None,
+    ) -> list[VectorHit]:
+        """Return the top-k nearest neighbours by cosine similarity.
+
+        ``scope`` filters at the metadata level (``shared`` if None).
+        Implementations MUST return an empty list when the store is empty,
+        never raise.
+        """
+        ...
+
+    def count(self) -> int:
+        """Total entity count across all scopes — cheap monitoring probe."""
+        ...
+
+    def drop(self) -> None:
+        """Wipe the underlying collection. Test / migration use only."""
+        ...

--- a/mcp/tests/unit/test_vector_store.py
+++ b/mcp/tests/unit/test_vector_store.py
@@ -1,0 +1,292 @@
+"""Contract tests for VectorStore implementations.
+
+Each implementation is run through the same suite via parametrize; a
+``FakeVectorStore`` lives alongside the tests so the contract is
+self-checked without needing live infra. Milvus is exercised through the
+adapter's *connection-deferred* path (no pymilvus install required at
+import time); behavioural Milvus tests live in
+``mcp/tests/integration/`` (Phase 5 PR3) and are gated by ZILLIZ_URI.
+"""
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pytest
+
+from kg_mcp.storage import VectorEntry, VectorHit, VectorStore
+from kg_mcp.storage.milvus import MilvusConfig, MilvusVectorStore
+from kg_mcp.storage.nano import NanoVectorDBVectorStore
+
+
+pytestmark = [pytest.mark.unit]
+
+
+# ─── Fake implementation — proves the protocol is usable from outside ──────
+
+
+class FakeVectorStore:
+    """In-memory store used in unit tests of consumers (not just the
+    contract suite). Naive O(n) cosine — fine for fixtures."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, VectorEntry] = {}
+
+    def upsert(self, entries: Iterable[VectorEntry]) -> int:
+        n = 0
+        for e in entries:
+            self._entries[e.entity_id] = e
+            n += 1
+        return n
+
+    def query(
+        self,
+        vector: Sequence[float],
+        *,
+        top_k: int = 5,
+        scope: str | None = None,
+    ) -> list[VectorHit]:
+        target = scope or "shared"
+        results: list[tuple[float, VectorEntry]] = []
+        for e in self._entries.values():
+            if e.scope != target:
+                continue
+            s = sum(a * b for a, b in zip(vector, e.vector))
+            results.append((s, e))
+        results.sort(key=lambda kv: kv[0], reverse=True)
+        return [VectorHit(entry=e, score=s) for s, e in results[:top_k]]
+
+    def count(self) -> int:
+        return len(self._entries)
+
+    def drop(self) -> None:
+        self._entries.clear()
+
+
+# ─── Protocol surface ─────────────────────────────────────────────────────
+
+
+def test_fake_satisfies_vector_store_protocol():
+    """Lock the protocol-typing contract: any duck-typed impl is accepted."""
+    store: VectorStore = FakeVectorStore()
+    assert isinstance(store, VectorStore)
+
+
+def test_nano_satisfies_protocol(tmp_path):
+    store: VectorStore = NanoVectorDBVectorStore(tmp_path / "missing.json")
+    assert isinstance(store, VectorStore)
+
+
+def test_milvus_satisfies_protocol():
+    store: VectorStore = MilvusVectorStore(
+        MilvusConfig(uri="https://placeholder.invalid", token="t")
+    )
+    assert isinstance(store, VectorStore)
+
+
+# ─── Shared behaviour suite ───────────────────────────────────────────────
+
+
+def _seed(store: VectorStore) -> None:
+    store.upsert([
+        VectorEntry(
+            entity_id="ent-alpha",
+            vector=[1.0, 0.0, 0.0],
+            entity_name="Alpha",
+            content="alpha entity",
+            source_id="duke:treats_symptom",
+            file_path="clinical_anchors",
+            scope="shared",
+        ),
+        VectorEntry(
+            entity_id="ent-beta",
+            vector=[0.0, 1.0, 0.0],
+            entity_name="Beta",
+            content="beta entity",
+            source_id="cmaup:target_disease",
+            file_path="clinical_anchors",
+            scope="shared",
+        ),
+        VectorEntry(
+            entity_id="ent-gamma-private",
+            vector=[0.0, 0.0, 1.0],
+            entity_name="Gamma",
+            content="private entity",
+            source_id="herb2:herb_disease",
+            file_path="clinical_anchors",
+            scope="tenant-foo",
+        ),
+    ])
+
+
+# Test against impls that don't need network. Nano gets a per-test
+# tmp_path so persistence is opt-in via the fixture wrapper below.
+
+
+def _nano(tmp_path: Path) -> NanoVectorDBVectorStore:
+    return NanoVectorDBVectorStore(tmp_path / "fixture.json")
+
+
+@pytest.fixture(params=["fake", "nano"])
+def store(request, tmp_path) -> VectorStore:
+    if request.param == "fake":
+        return FakeVectorStore()
+    return _nano(tmp_path)
+
+
+class TestVectorStoreContract:
+    def test_count_zero_on_fresh_store(self, store: VectorStore) -> None:
+        assert store.count() == 0
+
+    def test_upsert_then_count(self, store: VectorStore) -> None:
+        _seed(store)
+        assert store.count() == 3
+
+    def test_query_returns_nearest_neighbour(self, store: VectorStore) -> None:
+        _seed(store)
+        hits = store.query([1.0, 0.0, 0.0], top_k=1)
+        assert len(hits) == 1
+        assert hits[0].entry.entity_id == "ent-alpha"
+        # Cosine of identical unit vectors should be ~1.0.
+        assert hits[0].score == pytest.approx(1.0, abs=1e-6)
+
+    def test_query_respects_top_k(self, store: VectorStore) -> None:
+        _seed(store)
+        # Vector midway between alpha + beta — both should rank above
+        # the private gamma.
+        hits = store.query([0.7, 0.7, 0.0], top_k=2)
+        ids = [h.entry.entity_id for h in hits]
+        assert set(ids) == {"ent-alpha", "ent-beta"}
+
+    def test_query_returns_empty_on_empty_store(self, store: VectorStore) -> None:
+        assert store.query([1.0, 0.0, 0.0]) == []
+
+    def test_query_scope_isolation(self, store: VectorStore) -> None:
+        """A tenant-scoped entity must not surface in a `shared` query."""
+        _seed(store)
+        shared_ids = {
+            h.entry.entity_id
+            for h in store.query([0.0, 0.0, 1.0], top_k=5, scope="shared")
+        }
+        assert "ent-gamma-private" not in shared_ids
+        tenant_ids = {
+            h.entry.entity_id
+            for h in store.query([0.0, 0.0, 1.0], top_k=5, scope="tenant-foo")
+        }
+        assert "ent-gamma-private" in tenant_ids
+
+    def test_upsert_is_idempotent(self, store: VectorStore) -> None:
+        _seed(store)
+        _seed(store)  # second insert overwrites; doesn't add
+        assert store.count() == 3
+
+    def test_drop_clears_store(self, store: VectorStore) -> None:
+        _seed(store)
+        store.drop()
+        assert store.count() == 0
+        assert store.query([1.0, 0.0, 0.0]) == []
+
+
+# ─── Nano-specific: file format round-trip ────────────────────────────────
+
+
+class TestNanoFileFormat:
+    """The migration script (Phase 4 PR2) depends on Nano being able to
+    read the live ``vdb_entities.json`` shape. Pin the format here so a
+    LightRAG upgrade that changes the on-disk schema fails loudly."""
+
+    def test_reads_lightrag_nano_format(self, tmp_path: Path) -> None:
+        # Two 4-dim entries, base64-packed float32 row-major.
+        floats = [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+        blob = struct.pack(f"<{len(floats)}f", *floats)
+        import base64
+
+        payload = {
+            "embedding_dim": 4,
+            "data": [
+                {
+                    "__id__": "ent-a",
+                    "entity_name": "Alpha",
+                    "content": "alpha",
+                    "source_id": "duke:foo",
+                    "file_path": "clinical_anchors",
+                },
+                {
+                    "__id__": "ent-b",
+                    "entity_name": "Beta",
+                    "content": "beta",
+                    "source_id": "duke:foo",
+                    "file_path": "clinical_anchors",
+                },
+            ],
+            "matrix": base64.b64encode(blob).decode("ascii"),
+        }
+        path = tmp_path / "vdb_entities.json"
+        path.write_text(json.dumps(payload))
+
+        store = NanoVectorDBVectorStore(path)
+        assert store.count() == 2
+        hits = store.query([1.0, 0.0, 0.0, 0.0], top_k=1)
+        assert hits[0].entry.entity_id == "ent-a"
+        assert hits[0].entry.source_id == "duke:foo"
+
+    def test_persist_round_trip(self, tmp_path: Path) -> None:
+        """Opt-in persistence: write, drop the in-memory store, re-open,
+        confirm data was flushed to disk."""
+        path = tmp_path / "vdb_entities.json"
+        store = NanoVectorDBVectorStore(path, persist_on_upsert=True)
+        store.upsert([
+            VectorEntry(
+                entity_id="ent-x",
+                vector=[1.0, 0.0, 0.0, 0.0],
+                entity_name="X",
+                content="x",
+            ),
+        ])
+        # Reload from disk; in-memory state is discarded.
+        reopened = NanoVectorDBVectorStore(path)
+        assert reopened.count() == 1
+
+
+# ─── Milvus config — env wiring ───────────────────────────────────────────
+
+
+class TestMilvusConfig:
+    def test_from_env_requires_uri(self):
+        with pytest.raises(ValueError, match="ZILLIZ_URI"):
+            MilvusConfig.from_env({})
+
+    def test_from_env_token_path(self):
+        cfg = MilvusConfig.from_env(
+            {"ZILLIZ_URI": "https://x.serverless.zilliz", "ZILLIZ_TOKEN": "tok"}
+        )
+        assert cfg.uri == "https://x.serverless.zilliz"
+        assert cfg.token == "tok"
+        assert cfg.db_user is None
+
+    def test_from_env_db_password_path(self):
+        cfg = MilvusConfig.from_env({
+            "ZILLIZ_URI": "https://x.serverless.zilliz",
+            "ZILLIZ_DB_USER": "u",
+            "ZILLIZ_DB_PASSWORD": "p",
+        })
+        assert cfg.db_user == "u"
+        assert cfg.db_password == "p"
+        assert cfg.token is None
+
+    def test_from_env_default_collection(self):
+        cfg = MilvusConfig.from_env({
+            "ZILLIZ_URI": "https://x.zilliz",
+            "ZILLIZ_TOKEN": "t",
+        })
+        assert cfg.collection == "kg_entities"
+
+    def test_from_env_custom_embedding_dim(self):
+        cfg = MilvusConfig.from_env({
+            "ZILLIZ_URI": "https://x.zilliz",
+            "ZILLIZ_TOKEN": "t",
+            "EMBEDDING_DIM": "3072",
+        })
+        assert cfg.embedding_dim == 3072

--- a/shrine-diet-bioactivity/.env.template
+++ b/shrine-diet-bioactivity/.env.template
@@ -18,6 +18,24 @@ OPENROUTER_API_KEY=<paste-from-openrouter-keys-page>
 # Optional — only set if using non-default LightRAG storage backends
 # WORKING_DIR=./rag_storage_local
 
+# ---------------------------------------------------------------------------
+# Zilliz Cloud (Milvus) — vector store for LightRAG Layer-A semantic search.
+# Source of truth: Infisical project 687cab01-... env prod path /mcp/kg/
+# Pull via:  infisical run --env=prod --path=/mcp/kg/ -- python -m kg_mcp ...
+# Never paste raw values into this template or any tracked file.
+# ---------------------------------------------------------------------------
+# Selects which VectorStore impl the gateway uses: "milvus" (prod) | "nano" (local)
+KG_VECTOR_BACKEND=nano
+# Cluster URI from https://cloud.zilliz.com (Connect tab → Public Endpoint)
+ZILLIZ_URI=<paste-from-zilliz-console>
+# API key (preferred) — token-auth mode for serverless clusters.
+ZILLIZ_TOKEN=<from-infisical>
+# DB user + password (alternate auth — only set if not using token mode).
+ZILLIZ_DB_USER=<from-infisical>
+ZILLIZ_DB_PASSWORD=<from-infisical>
+# Logical collection name — single collection with `scope` as metadata field.
+ZILLIZ_COLLECTION=kg_entities
+
 # Optional fallbacks (only if OpenRouter is unreachable)
 # OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=sk-ant-...


### PR DESCRIPTION
First slice of the **LightRAG vectors → Zilliz Milvus** migration stack
(3 PRs total — see `/plan` discussion).

This PR introduces the DI seam without changing any runtime behaviour: the
gateway still reads/writes the existing NanoVectorDB files by default.
Wiring + migration land in PR2; tests + deploy land in PR3.

## Summary

- **Phase 1 — Infisical sync + env templates**
  - Created `/mcp/kg/` folder in Infisical (project `687cab01-...`, env `prod`).
  - 5 secrets seeded: `ZILLIZ_TOKEN`, `ZILLIZ_DB_USER`, `ZILLIZ_DB_PASSWORD`, `ZILLIZ_COLLECTION` (=`kg_entities`), `ZILLIZ_URI` (placeholder — needs the cluster public endpoint).
  - `shrine-diet-bioactivity/.env.template`: added Zilliz section.
  - New `mcp/.env.template`: documents the gateway's full env surface (no raw values).

- **Phase 2 — VectorStore protocol + adapters**
  - `mcp/src/kg_mcp/storage/vector_store.py` — `Protocol` + `VectorEntry` / `VectorHit` dataclasses. Single shared collection with `scope` as a metadata field.
  - `mcp/src/kg_mcp/storage/nano.py` — reads the live LightRAG `vdb_entities.json` (base64 float32 matrix + per-entry data list). Brute-force cosine on normalised vectors. Read-only by default; `persist_on_upsert=True` opt-in for the Phase-4 migration script.
  - `mcp/src/kg_mcp/storage/milvus.py` — `pymilvus` adapter. Token-auth preferred (Zilliz serverless), user/password fallback. HNSW COSINE index, dim from `EMBEDDING_DIM` (default 2048 = current `nvidia/llama-nemotron-embed-vl-1b-v2:free`). Import deferred so unit tests don't require pymilvus.
  - `pyproject.toml`: added `[project.optional-dependencies] vector-milvus = ["pymilvus>=2.4"]`.

## Test plan

- [x] 26 new tests in `mcp/tests/unit/test_vector_store.py`:
  - Protocol satisfaction for Fake / Nano / Milvus.
  - Shared behaviour contract (parametrized over Fake + Nano).
  - Nano on-disk format round-trip (locks the LightRAG schema).
  - MilvusConfig env-wiring.
- [x] Full mcp suite: 144/144 pass (was 116, +28 from this PR).
- [ ] CI green.
- [ ] PR2 (Phase 3 + 4): wire into `scoped_server.py`, run Path-A migration.
- [ ] PR3 (Phase 5 + 6): integration + agentic E2E tests, Railway deploy.

## Path A validation (transfer existing vectors)

Verified locally before opening this PR — the migration is viable without re-embedding:

- Source: `shrine-diet-bioactivity/lightrag/rag_storage_clinical_embed/unified_diet_kg/vdb_entities.json` (413 MB)
- Embedding dim: **2048** (matches `EMBEDDING_DIM` default)
- Row count: **26,191 entities** (matches earlier embed run)
- Matrix shape: `26191 × 2048` float32, base64-packed — decodable cleanly

## Risk

Low — this PR adds new modules, no existing module calls them yet. Default `KG_VECTOR_BACKEND=nano` preserves current behaviour.

## Security note

The Zilliz credentials were pasted into chat. They've been mirrored to Infisical via this PR. **Rotate at the Zilliz console immediately** so the chat-leaked values are invalidated, then re-write the rotated values back to Infisical.