### PR TITLE
feat(lightrag): KG_VECTOR_BACKEND switch + Zilliz→Milvus env shim + Path-A migrator (PR2/3)

### DIFF
--- a/mcp/.env.template
+++ b/mcp/.env.template
@@ -28,6 +28,11 @@ KG_VECTOR_BACKEND=nano
 
 # Zilliz / Milvus — only consulted when KG_VECTOR_BACKEND=milvus.
 # Source: Infisical /mcp/kg/  (project 687cab01-..., env prod)
+#
+# scoped_server.py applies a startup shim that mirrors these onto
+# MILVUS_URI / MILVUS_TOKEN / MILVUS_USER / MILVUS_PASSWORD so LightRAG's
+# bundled MilvusVectorDBStorage finds them. You can also set MILVUS_* keys
+# directly — those win over the shim (operator override).
 ZILLIZ_URI=<paste-from-zilliz-console>
 ZILLIZ_TOKEN=<from-infisical>
 ZILLIZ_DB_USER=<from-infisical>

--- a/shrine-diet-bioactivity/lightrag/scoped_server.py
+++ b/shrine-diet-bioactivity/lightrag/scoped_server.py
@@ -68,6 +68,65 @@ def _load_config() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Vector backend selection (PR2 of Milvus migration stack)
+# ---------------------------------------------------------------------------
+
+
+_VECTOR_BACKEND_MAP = {
+    "nano": "NanoVectorDBStorage",
+    "milvus": "MilvusVectorDBStorage",
+}
+
+
+def _resolve_vector_storage(env) -> str:
+    """Pick the LightRAG ``vector_storage`` class name from env.
+
+    Default is ``nano`` so the gateway boots with no behaviour change
+    until ``KG_VECTOR_BACKEND=milvus`` is set explicitly. Raises on
+    unknown values so a typo can't silently fall through to the default.
+    """
+    raw = (env.get("KG_VECTOR_BACKEND") or "nano").strip().lower()
+    impl = _VECTOR_BACKEND_MAP.get(raw)
+    if impl is None:
+        raise ValueError(
+            f"KG_VECTOR_BACKEND={raw!r} is not supported. "
+            f"Valid values: {sorted(_VECTOR_BACKEND_MAP)}"
+        )
+    return impl
+
+
+def _apply_zilliz_env_shim(env) -> None:
+    """Mirror ZILLIZ_* secrets onto LightRAG's MILVUS_* env-var names.
+
+    Why: secrets are stored at Infisical path ``/mcp/kg/`` as ``ZILLIZ_*``
+    (matches the Zilliz Cloud console). LightRAG's bundled
+    ``MilvusVectorDBStorage`` reads ``MILVUS_URI``, ``MILVUS_TOKEN``, etc.
+    This shim makes both naming schemes co-exist without renaming either.
+
+    Precedence: an explicit ``MILVUS_*`` value already in env wins (operator
+    override). Only ``ZILLIZ_*`` keys that have non-empty values are
+    forwarded — so a partial secret set doesn't pollute env with empty
+    ``MILVUS_*`` keys.
+
+    Mutates ``env`` in place (typically ``os.environ``).
+    """
+    aliases = {
+        "ZILLIZ_URI": "MILVUS_URI",
+        "ZILLIZ_TOKEN": "MILVUS_TOKEN",
+        "ZILLIZ_DB_USER": "MILVUS_USER",
+        "ZILLIZ_DB_PASSWORD": "MILVUS_PASSWORD",
+        "ZILLIZ_DB_NAME": "MILVUS_DB_NAME",
+    }
+    for source, target in aliases.items():
+        value = env.get(source)
+        if not value:
+            continue
+        if env.get(target):
+            continue
+        env[target] = value
+
+
+# ---------------------------------------------------------------------------
 # LightRAG factory — registers ScopedNeo4JStorage and returns a booted rag
 # ---------------------------------------------------------------------------
 
@@ -189,10 +248,23 @@ async def _build_scoped_rag() -> Any:
     if llm_binding == "ollama":
         llm_kwargs = {"host": llm_host, "options": {"num_ctx": 32768}}
 
+    # PR2 of Milvus migration stack — pick the vector backend and apply
+    # the ZILLIZ_*→MILVUS_* env shim so LightRAG's bundled
+    # ``MilvusVectorDBStorage`` finds the secrets we mirror in from
+    # Infisical /mcp/kg/. Default ``nano`` preserves prior behaviour.
+    _apply_zilliz_env_shim(os.environ)
+    vector_storage = _resolve_vector_storage(os.environ)
+    logger.info(
+        "vector backend: %s (KG_VECTOR_BACKEND=%s)",
+        vector_storage,
+        os.environ.get("KG_VECTOR_BACKEND", "nano"),
+    )
+
     rag = LightRAG(
         working_dir=working_dir,
         workspace=workspace,
         graph_storage="ScopedNeo4JStorage",
+        vector_storage=vector_storage,
         llm_model_func=llm_func,
         llm_model_name=llm_model,
         llm_model_kwargs=llm_kwargs,

--- a/shrine-diet-bioactivity/lightrag/tests/test_vector_backend_selection.py
+++ b/shrine-diet-bioactivity/lightrag/tests/test_vector_backend_selection.py
@@ -1,0 +1,100 @@
+"""Unit tests for the KG_VECTOR_BACKEND switch + ZILLIZ_*→MILVUS_* shim.
+
+The shim lives in scoped_server.py (helper: ``_apply_zilliz_env_shim``).
+It maps the Infisical-stored Zilliz creds onto the env-var names LightRAG's
+``MilvusVectorDBStorage`` actually reads. Locking this so a future rename
+of either side doesn't silently break ingestion.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scoped_server import (  # noqa: E402
+    _apply_zilliz_env_shim,
+    _resolve_vector_storage,
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+# ─── env shim ─────────────────────────────────────────────────────────────
+
+
+class TestZillizEnvShim:
+    def test_maps_token_when_milvus_unset(self):
+        env = {
+            "ZILLIZ_URI": "https://x.zilliz.cloud",
+            "ZILLIZ_TOKEN": "tok-abc",
+            "ZILLIZ_DB_USER": "u",
+            "ZILLIZ_DB_PASSWORD": "p",
+        }
+        _apply_zilliz_env_shim(env)
+        assert env["MILVUS_URI"] == "https://x.zilliz.cloud"
+        assert env["MILVUS_TOKEN"] == "tok-abc"
+        assert env["MILVUS_USER"] == "u"
+        assert env["MILVUS_PASSWORD"] == "p"
+
+    def test_preserves_existing_milvus_values(self):
+        """Operator override wins: if both ZILLIZ_* and MILVUS_* are set, the
+        MILVUS_* value takes precedence (it's the more specific name)."""
+        env = {
+            "MILVUS_URI": "https://override.zilliz.cloud",
+            "ZILLIZ_URI": "https://from-infisical.zilliz.cloud",
+        }
+        _apply_zilliz_env_shim(env)
+        assert env["MILVUS_URI"] == "https://override.zilliz.cloud"
+
+    def test_no_zilliz_no_change(self):
+        env = {"OPENROUTER_API_KEY": "x"}
+        before = dict(env)
+        _apply_zilliz_env_shim(env)
+        assert env == before
+
+    def test_partial_secrets_partial_shim(self):
+        """Only the secrets actually present are forwarded — no empty
+        MILVUS_PASSWORD when ZILLIZ_DB_PASSWORD wasn't set."""
+        env = {"ZILLIZ_URI": "u", "ZILLIZ_TOKEN": "t"}
+        _apply_zilliz_env_shim(env)
+        assert env.get("MILVUS_URI") == "u"
+        assert env.get("MILVUS_TOKEN") == "t"
+        assert "MILVUS_USER" not in env
+        assert "MILVUS_PASSWORD" not in env
+
+
+# ─── KG_VECTOR_BACKEND selection ──────────────────────────────────────────
+
+
+class TestVectorStorageSelection:
+    def test_default_is_nano(self):
+        """Backwards-compat: an unset env keeps the existing NanoVectorDB
+        behaviour so PR1+PR2 land without changing the live gateway."""
+        assert _resolve_vector_storage({}) == "NanoVectorDBStorage"
+
+    def test_explicit_nano(self):
+        assert (
+            _resolve_vector_storage({"KG_VECTOR_BACKEND": "nano"})
+            == "NanoVectorDBStorage"
+        )
+
+    def test_milvus_switch(self):
+        assert (
+            _resolve_vector_storage({"KG_VECTOR_BACKEND": "milvus"})
+            == "MilvusVectorDBStorage"
+        )
+
+    def test_case_insensitive(self):
+        assert (
+            _resolve_vector_storage({"KG_VECTOR_BACKEND": "Milvus"})
+            == "MilvusVectorDBStorage"
+        )
+
+    def test_invalid_backend_raises(self):
+        with pytest.raises(ValueError, match="KG_VECTOR_BACKEND"):
+            _resolve_vector_storage({"KG_VECTOR_BACKEND": "redis"})

--- a/shrine-diet-bioactivity/scripts/migrate_nano_to_milvus.py
+++ b/shrine-diet-bioactivity/scripts/migrate_nano_to_milvus.py
@@ -1,0 +1,251 @@
+"""Path-A migration: transfer NanoVectorDB vectors into Milvus.
+
+Reads ``rag_storage_clinical_embed/<workspace>/vdb_entities.json`` (and the
+sibling ``vdb_relationships.json`` / ``vdb_chunks.json`` if present),
+decodes the base64-packed float32 matrix, and bulk-upserts into the
+LightRAG-managed Milvus collection. Avoids re-embedding entirely.
+
+Why Path A: the existing 26,141 entities × 2048-dim file was produced by
+``embed_clinical_entities.py`` against OpenRouter
+``nvidia/llama-nemotron-embed-vl-1b-v2:free``. The same model serves
+queries via ``scoped_server.py``; the vectors are still query-consistent
+and re-embedding would burn 27 minutes for an identical index.
+
+Schema alignment: this script does NOT bypass LightRAG's collection
+bootstrap. It boots a LightRAG instance pointing at Milvus (so LightRAG
+creates the collection with its expected schema), then uses ``pymilvus``
+directly to upsert rows. That guarantees the schema LightRAG expects at
+query time matches what we write at migration time.
+
+Usage::
+
+    cd shrine-diet-bioactivity/lightrag
+    KG_VECTOR_BACKEND=milvus \\
+    WORKSPACE=unified_diet_kg \\
+    infisical run --env=prod --path=/mcp/kg/ -- \\
+        python ../scripts/migrate_nano_to_milvus.py \\
+            --working-dir ./rag_storage_clinical_embed \\
+            --dry-run            # preview counts without writing
+
+Drop ``--dry-run`` to commit. The script is idempotent — re-running on a
+fully-migrated collection is a no-op (Milvus upsert semantics).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import os
+import struct
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LIGHTRAG_DIR = SCRIPT_DIR.parent / "lightrag"
+sys.path.insert(0, str(LIGHTRAG_DIR))
+
+
+# ---------------------------------------------------------------------------
+# NanoVectorDB JSON reader
+# ---------------------------------------------------------------------------
+
+
+def _decode_nano(path: Path) -> tuple[int, list[dict], list[list[float]]]:
+    """Return ``(embedding_dim, data_rows, matrix)`` from a vdb_*.json file."""
+    raw = json.loads(path.read_text())
+    dim = int(raw.get("embedding_dim") or 0)
+    data = raw.get("data") or []
+    matrix_b64 = raw.get("matrix") or ""
+    if not (matrix_b64 and dim and data):
+        return dim, [], []
+    blob = base64.b64decode(matrix_b64)
+    n_floats = len(blob) // 4
+    unpacked = struct.unpack(f"<{n_floats}f", blob)
+    matrix = [list(unpacked[i : i + dim]) for i in range(0, n_floats, dim)]
+    return dim, data, matrix
+
+
+# ---------------------------------------------------------------------------
+# LightRAG bootstrap — ensure the Milvus collection exists with the right schema
+# ---------------------------------------------------------------------------
+
+
+async def _bootstrap_lightrag_milvus() -> Any:
+    """Boot LightRAG with KG_VECTOR_BACKEND=milvus so it creates the
+    Milvus collection at the schema LightRAG itself expects to read."""
+    from scoped_server import _build_scoped_rag  # noqa: E402
+
+    rag = await _build_scoped_rag()
+    return rag
+
+
+# ---------------------------------------------------------------------------
+# Migration core
+# ---------------------------------------------------------------------------
+
+
+def _milvus_client():
+    """Return a pymilvus client built from the (already-shimmed) env."""
+    from pymilvus import MilvusClient  # noqa: E402
+
+    uri = os.environ["MILVUS_URI"]
+    token = os.environ.get("MILVUS_TOKEN")
+    user = os.environ.get("MILVUS_USER")
+    password = os.environ.get("MILVUS_PASSWORD")
+
+    if token:
+        return MilvusClient(uri=uri, token=token)
+    if user and password:
+        return MilvusClient(uri=uri, user=user, password=password)
+    raise RuntimeError(
+        "Migration needs MILVUS_TOKEN or MILVUS_USER + MILVUS_PASSWORD."
+    )
+
+
+def _migrate_file(
+    nano_path: Path,
+    collection_name: str,
+    batch_size: int,
+    *,
+    dry_run: bool,
+) -> dict:
+    """Migrate a single vdb_*.json into the named Milvus collection."""
+    print(f"  reading {nano_path.name} ...", flush=True)
+    dim, data, matrix = _decode_nano(nano_path)
+    n = len(data)
+    print(f"    {n} entries × {dim}-dim", flush=True)
+    if n == 0:
+        return {"file": nano_path.name, "written": 0, "skipped": 0}
+    assert len(matrix) == n, f"row mismatch in {nano_path}"
+
+    if dry_run:
+        return {"file": nano_path.name, "written": 0, "would_write": n}
+
+    client = _milvus_client()
+    written = 0
+    started = time.time()
+    for offset in range(0, n, batch_size):
+        batch_rows = data[offset : offset + batch_size]
+        batch_vecs = matrix[offset : offset + batch_size]
+        records = [
+            {
+                "id": row.get("__id__", ""),
+                "vector": batch_vecs[i],
+                "created_at": int(row.get("__created_at__", 0)),
+                "content": (row.get("content") or "")[:8000],
+                "entity_name": row.get("entity_name", ""),
+                "source_id": row.get("source_id", ""),
+                "file_path": row.get("file_path", ""),
+            }
+            for i, row in enumerate(batch_rows)
+        ]
+        client.upsert(collection_name=collection_name, data=records)
+        written += len(records)
+        elapsed = time.time() - started
+        rate = written / elapsed if elapsed else 0
+        print(
+            f"    [{written}/{n}] rate={rate:.0f}/s",
+            flush=True,
+        )
+    return {"file": nano_path.name, "written": written, "total": n}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _argparser() -> argparse.ArgumentParser:
+    description = "Migrate NanoVectorDB vectors into Milvus (Path A)."
+    ap = argparse.ArgumentParser(description=description)
+    ap.add_argument(
+        "--working-dir",
+        type=Path,
+        required=True,
+        help="Path to the rag_storage_* directory containing the workspace folder.",
+    )
+    ap.add_argument(
+        "--workspace",
+        default=os.environ.get("WORKSPACE", "unified_diet_kg"),
+        help="LightRAG workspace name (matches Aura :workspace label).",
+    )
+    ap.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        help="Upsert batch size (Zilliz serverless caps payload; default 500).",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print counts only; do not write to Milvus.",
+    )
+    return ap
+
+
+def main() -> int:
+    args = _argparser().parse_args()
+
+    workspace_dir = args.working_dir / args.workspace
+    if not workspace_dir.exists():
+        print(
+            f"ERROR: working dir not found: {workspace_dir}", file=sys.stderr
+        )
+        return 2
+
+    # Step 1: env shim + verify the secrets are present.
+    from scoped_server import _apply_zilliz_env_shim  # noqa: E402
+
+    _apply_zilliz_env_shim(os.environ)
+    if not args.dry_run and not os.environ.get("MILVUS_URI"):
+        print(
+            "ERROR: MILVUS_URI (or ZILLIZ_URI) not set. "
+            "Source from Infisical /mcp/kg/. ",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Step 2: bootstrap LightRAG against Milvus so the collection exists
+    # at the LightRAG-expected schema. Skipped in dry-run mode.
+    if not args.dry_run:
+        os.environ["KG_VECTOR_BACKEND"] = "milvus"
+        print("Bootstrapping LightRAG → Milvus (creates collection on first run)")
+        rag = asyncio.run(_bootstrap_lightrag_milvus())
+        # ``rag.entities_vdb`` is the LightRAG-side wrapper; its
+        # ``namespace`` is the actual Milvus collection name.
+        entities_col = rag.entities_vdb.namespace
+        rels_col = rag.relationships_vdb.namespace
+        chunks_col = rag.chunks_vdb.namespace
+    else:
+        entities_col = rels_col = chunks_col = "<dry-run>"
+
+    # Step 3: walk the workspace dir and migrate each known vdb file.
+    files = {
+        "vdb_entities.json": entities_col,
+        "vdb_relationships.json": rels_col,
+        "vdb_chunks.json": chunks_col,
+    }
+
+    summary = []
+    for fname, col in files.items():
+        path = workspace_dir / fname
+        if not path.exists():
+            print(f"  skipping {fname} — not present in {workspace_dir}")
+            continue
+        print(f"\n>>> Migrating {fname} → collection {col!r}")
+        result = _migrate_file(
+            path, col, args.batch_size, dry_run=args.dry_run
+        )
+        summary.append(result)
+
+    print("\nDone.")
+    for s in summary:
+        print(f"  {s}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shrine-diet-bioactivity/scripts/tests/test_migrate_nano_to_milvus.py
+++ b/shrine-diet-bioactivity/scripts/tests/test_migrate_nano_to_milvus.py
@@ -1,0 +1,123 @@
+"""Smoke + format-decoder tests for migrate_nano_to_milvus.py.
+
+The full migration is a network operation against Zilliz that we don't
+exercise in unit tests. These tests cover the pure-logic surface:
+
+* CLI parses --help and --dry-run cleanly.
+* ``_decode_nano`` correctly parses the LightRAG vdb_*.json shape and
+  returns matched ``(dim, data, matrix)`` triples.
+* Missing workspace dir exits 2 (not 0).
+"""
+from __future__ import annotations
+
+import base64
+import json
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent / "migrate_nano_to_milvus.py"
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+# ─── CLI smoke ────────────────────────────────────────────────────────────
+
+
+def test_help_exits_zero():
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0
+    out = (proc.stdout + proc.stderr).lower()
+    assert "migrate" in out
+    assert "--working-dir" in out
+    assert "--dry-run" in out
+
+
+def test_missing_working_dir_exits_2(tmp_path):
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--working-dir",
+            str(tmp_path / "absent"),
+            "--workspace",
+            "ws",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 2
+    assert "not found" in (proc.stdout + proc.stderr).lower()
+
+
+# ─── _decode_nano ─────────────────────────────────────────────────────────
+
+
+def _build_fixture(tmp_path: Path, dim: int = 4, n: int = 3) -> Path:
+    """Write a minimal vdb_*.json mirroring the LightRAG shape."""
+    floats = [float((i * dim + j) % 7) for i in range(n) for j in range(dim)]
+    blob = struct.pack(f"<{len(floats)}f", *floats)
+    payload = {
+        "embedding_dim": dim,
+        "data": [
+            {
+                "__id__": f"ent-{i}",
+                "__created_at__": 1779676637 + i,
+                "entity_name": f"E{i}",
+                "content": f"content {i}",
+                "source_id": f"duke:{i}",
+                "file_path": "clinical_anchors",
+            }
+            for i in range(n)
+        ],
+        "matrix": base64.b64encode(blob).decode("ascii"),
+    }
+    path = tmp_path / "vdb_entities.json"
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_decode_nano_reads_shape(tmp_path):
+    # Import via subprocess-free runtime path so we exercise the actual module.
+    sys.path.insert(0, str(SCRIPT.parent))
+    try:
+        from migrate_nano_to_milvus import _decode_nano  # type: ignore
+
+        path = _build_fixture(tmp_path, dim=4, n=3)
+        dim, data, matrix = _decode_nano(path)
+        assert dim == 4
+        assert len(data) == 3
+        assert len(matrix) == 3
+        assert len(matrix[0]) == 4
+        assert data[0]["__id__"] == "ent-0"
+    finally:
+        sys.path.remove(str(SCRIPT.parent))
+
+
+def test_decode_nano_handles_empty_file(tmp_path):
+    sys.path.insert(0, str(SCRIPT.parent))
+    try:
+        from migrate_nano_to_milvus import _decode_nano  # type: ignore
+
+        empty_path = tmp_path / "vdb_entities.json"
+        empty_path.write_text(json.dumps({"embedding_dim": 0, "data": [], "matrix": ""}))
+        dim, data, matrix = _decode_nano(empty_path)
+        assert dim == 0
+        assert data == []
+        assert matrix == []
+    finally:
+        sys.path.remove(str(SCRIPT.parent))


### PR DESCRIPTION
Second slice of the **LightRAG vectors → Zilliz Milvus** migration stack.

This PR adds the DI seam in \`scoped_server.py\` and the Path-A migration
script, without changing any runtime behaviour (default \`KG_VECTOR_BACKEND=nano\`
preserves the existing live gateway).

## Summary

- **Phase 3 — DI wiring**
  - \`_resolve_vector_storage(env)\` picks LightRAG's \`vector_storage\` class from \`KG_VECTOR_BACKEND\` (\`nano\` | \`milvus\`). Default is \`nano\`. Unknown values raise.
  - \`_apply_zilliz_env_shim(env)\` mirrors \`ZILLIZ_URI/TOKEN/DB_USER/DB_PASSWORD/DB_NAME\` → \`MILVUS_*\` so LightRAG's bundled \`MilvusVectorDBStorage\` finds the Infisical-stored creds. Explicit \`MILVUS_*\` wins.
  - \`_build_scoped_rag\` calls both helpers and passes the resolved class through to \`LightRAG(...)\`.
- **Phase 4 — Migration script**
  - \`scripts/migrate_nano_to_milvus.py\` reads \`vdb_entities.json\` / \`vdb_relationships.json\` / \`vdb_chunks.json\`, decodes the base64 float32 matrix, and bulk-upserts to the LightRAG-managed Milvus collections.
  - Uses LightRAG's own bootstrap to create the collection — no schema duplication.
  - Idempotent + dry-runnable.

## Test plan

- [x] 9 unit tests in \`lightrag/tests/test_vector_backend_selection.py\` for the shim + selector (default, explicit, override, case-insensitive, partial-secret, invalid).
- [x] 4 unit tests in \`scripts/tests/test_migrate_nano_to_milvus.py\` (\`--help\`, missing dir exits 2, JSON-format round-trip + empty file).
- [x] Full mcp suite: 144/144 pass (unchanged from PR1).
- [ ] CI green.
- [ ] Operator: set \`ZILLIZ_URI\` in Infisical (currently a placeholder), run \`migrate_nano_to_milvus.py --dry-run\`, then commit.
- [ ] PR3: Railway env wiring + integration tests + agentic E2E.

## Risk

Low. Default backend unchanged; the new code paths are unreachable until \`KG_VECTOR_BACKEND=milvus\` is set in the deployed env.