### PR TITLE
feat(kg-mcp): Milvus integration + agentic E2E + CI/deploy wiring (PR3/3)

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -13,6 +13,9 @@
 # Required repo secrets:
 #   NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD — Aura connection (set in Railway dashboard, NOT here)
 #   OPENROUTER_API_KEY — for embedder + LLM (set in Railway dashboard)
+#   ZILLIZ_URI, ZILLIZ_TOKEN — Milvus vector store (set in Railway dashboard;
+#     mirrored from Infisical /mcp/kg/; required when KG_VECTOR_BACKEND=milvus)
+#   KG_VECTOR_BACKEND — "nano" (default) | "milvus" — selects the vector backend
 # Required Railway service:
 #   kg-mcp — single combined service (scoped_server + MCP gateway)
 

--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -143,6 +143,43 @@ jobs:
           # pytest tier should skip cleanly — that's the fork-safe path.
           python -m pytest tests/test_aura_data_integrity.py -v -rs
 
+  # =========================================================================
+  # Milvus vector-store integration — gated by ZILLIZ_URI presence (PR3 of
+  # Milvus migration stack). PRs from forks skip cleanly; same-repo PRs
+  # and trusted runs execute against the live Zilliz cluster.
+  # =========================================================================
+  milvus-integration:
+    name: Milvus VectorStore (integration)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install MCP + vector-milvus extras + test deps
+        run: pip install -e '.[test,vector-milvus]'
+
+      - name: Run Milvus integration tier
+        env:
+          ZILLIZ_URI: ${{ secrets.ZILLIZ_URI }}
+          ZILLIZ_TOKEN: ${{ secrets.ZILLIZ_TOKEN }}
+          EMBEDDING_DIM: '4'  # tiny dim for fast schema bootstrap
+        run: |
+          # ``-m integration`` flips the default deselect.
+          # When ZILLIZ_URI is empty the tests skip cleanly via the
+          # _milvus_env() helper; with secrets they run end-to-end.
+          python -m pytest tests/integration/test_milvus_vectorstore.py -v -rs -m integration
+
   test-coverage-ratio:
     name: Real-integration ratio (regression floor)
     runs-on: ubuntu-latest

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -34,6 +34,11 @@ test = [
 vector-milvus = [
     "pymilvus>=2.4",
 ]
+# Agentic E2E extras — only needed when running tests/e2e/test_agentic_*.
+# Skips cleanly without the SDK; CI installs on the dedicated agentic job.
+agentic = [
+    "anthropic>=0.40",
+]
 
 [project.scripts]
 kg-mcp-server = "kg_mcp.server:main"

--- a/mcp/tests/e2e/test_agentic_kg_query.py
+++ b/mcp/tests/e2e/test_agentic_kg_query.py
@@ -1,0 +1,220 @@
+"""Agentic E2E — minimal Anthropic SDK tool-use loop against live kg-mcp.
+
+Goal: prove an LLM agent, given only the gateway URL + bearer token,
+can successfully ground a clinical-style question on the live KG. Locks
+the "functional prototype readiness" criterion the migration is in
+service of (Phase 5 of the plan).
+
+Loop is intentionally tiny — one tool registered (``kg_query``), one
+back-and-forth, then we assert the agent's reply cites at least one
+provenance source_id matching the documented prefix regex.
+
+Gating: three env vars must all be present, or the test skips cleanly:
+
+  * ``KG_MCP_E2E_URL``      — gateway base URL, e.g. ``https://kg-mcp-test.up.railway.app``
+  * ``KG_MCP_API_KEY``      — bearer token enforced on /mcp
+  * ``ANTHROPIC_API_KEY``   — for the SDK loop
+
+Why not AG2: AG2 is heavyweight (multi-agent orchestration). For a single
+tool-use loop, the bare Anthropic SDK is one file and avoids pulling AG2
+into the kg-mcp test path. Per architectural choice in /plan discussion.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+
+import httpx
+import pytest
+
+
+pytestmark = [pytest.mark.e2e]
+
+
+_SOURCE_PREFIX = re.compile(
+    r"\b(duke|cmaup|herb2|symmap|hdi-safe-50|opentcm|food):[A-Za-z0-9_\-]+",
+    re.IGNORECASE,
+)
+
+
+def _env_or_skip(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        pytest.skip(f"{name} not set; agentic E2E skipped.")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Minimal kg-mcp client — initialise, call one tool, return the typed payload
+# ---------------------------------------------------------------------------
+
+
+def _mcp_call(url: str, key: str, tool: str, arguments: dict) -> dict:
+    """Invoke a single MCP tool via streamable-HTTP. Returns the typed
+    structuredContent payload (or the envelope dict on isError)."""
+    h = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    with httpx.Client(timeout=60.0) as c:
+        # initialize
+        r = c.post(
+            f"{url}/mcp",
+            headers=h,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "agentic-e2e", "version": "0.1"},
+                },
+            },
+        )
+        r.raise_for_status()
+        sid = r.headers["mcp-session-id"]
+        h2 = {**h, "mcp-session-id": sid}
+        c.post(
+            f"{url}/mcp",
+            headers=h2,
+            json={
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            },
+        )
+        # tools/call
+        r = c.post(
+            f"{url}/mcp",
+            headers=h2,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments},
+            },
+        )
+        r.raise_for_status()
+        body = None
+        for line in r.text.splitlines():
+            if line.startswith("data: "):
+                body = json.loads(line[6:])
+                break
+        if body is None:
+            body = r.json()
+        envelope = body.get("result", {}) or {}
+        return envelope.get("structuredContent") or envelope
+
+
+# ---------------------------------------------------------------------------
+# The actual agentic loop
+# ---------------------------------------------------------------------------
+
+
+def test_agent_uses_kg_query_and_cites_provenance():
+    """One-turn agentic loop: the model picks ``kg_query``, gets a real
+    payload, and produces a final reply that cites ≥ 1 provenance
+    source_id matching the documented prefix regex.
+
+    A skip-clean PRO TIP: pre-fund OpenRouter / Anthropic in CI with a
+    tiny budget; the loop costs < $0.005 per run.
+    """
+    url = _env_or_skip("KG_MCP_E2E_URL")
+    key = _env_or_skip("KG_MCP_API_KEY")
+    anthropic_key = _env_or_skip("ANTHROPIC_API_KEY")
+
+    try:
+        from anthropic import Anthropic
+    except ImportError:
+        pytest.skip("anthropic SDK not installed in this test env.")
+
+    client = Anthropic(api_key=anthropic_key)
+    tools = [
+        {
+            "name": "kg_query",
+            "description": (
+                "Search the Syntropy clinical knowledge graph for "
+                "compounds, herbs, foods, targets, diseases, and symptoms. "
+                "Returns ranked entities with provenance source_ids."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "Natural-language question about diet/herbs/compounds.",
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["local", "global", "hybrid", "naive", "mix"],
+                        "default": "local",
+                    },
+                    "top_k": {"type": "integer", "default": 3},
+                },
+                "required": ["question"],
+            },
+        }
+    ]
+    user_msg = (
+        "What compounds in Astragalus membranaceus help with immune "
+        "function? Use the kg_query tool, then summarize the top finding "
+        "and include the source_id of at least one supporting edge."
+    )
+
+    # Turn 1 — model decides whether to call the tool.
+    resp = client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=1024,
+        tools=tools,
+        messages=[{"role": "user", "content": user_msg}],
+    )
+
+    tool_use = next(
+        (c for c in resp.content if getattr(c, "type", "") == "tool_use"),
+        None,
+    )
+    assert tool_use is not None, (
+        f"Model didn't call kg_query. stop_reason={resp.stop_reason} "
+        f"content={[c.type for c in resp.content]}"
+    )
+    assert tool_use.name == "kg_query"
+
+    # Execute the tool against the live gateway.
+    tool_result = _mcp_call(url, key, "kg_query", dict(tool_use.input))
+
+    # Turn 2 — feed the tool result back; model summarises.
+    final = client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=1024,
+        tools=tools,
+        messages=[
+            {"role": "user", "content": user_msg},
+            {"role": "assistant", "content": resp.content},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_use.id,
+                        "content": json.dumps(tool_result)[:8000],
+                    }
+                ],
+            },
+        ],
+    )
+    final_text = "\n".join(
+        c.text for c in final.content if getattr(c, "type", "") == "text"
+    )
+    assert final_text.strip(), f"empty final reply; got {final.content!r}"
+
+    # Provenance discipline: the reply must include at least one
+    # source_id matching the documented prefix regex. This is a strong
+    # signal that the agent actually used the KG payload (rather than
+    # hallucinating around it).
+    assert _SOURCE_PREFIX.search(final_text), (
+        "Agent reply lacks a documented source_id prefix — provenance "
+        f"discipline failed.\n--- reply ---\n{final_text[:800]}"
+    )

--- a/mcp/tests/integration/test_milvus_vectorstore.py
+++ b/mcp/tests/integration/test_milvus_vectorstore.py
@@ -1,0 +1,127 @@
+"""Live integration tests for MilvusVectorStore against Zilliz/Milvus.
+
+Gated by ``ZILLIZ_URI`` (or ``MILVUS_URI``) in the environment. When the
+secret is absent — PRs from forks, fresh dev clones — every test in this
+module skips cleanly with a clear reason. Trusted CI runs that have the
+secret mirrored from Infisical will execute these.
+
+These are *not* unit tests — they hit a real cluster. The collection used
+is a per-run sentinel (``test_kg_entities_<uuid>``) so we never collide
+with the prod ``kg_entities`` collection. The tests drop the sentinel
+collection on teardown so a failed run doesn't leak storage.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from kg_mcp.storage import VectorEntry
+from kg_mcp.storage.milvus import MilvusConfig, MilvusVectorStore
+
+
+pytestmark = [pytest.mark.integration]
+
+
+def _milvus_env() -> dict[str, str]:
+    """Snapshot the Milvus env vars or skip if URI is missing."""
+    env = {
+        k: os.environ[k]
+        for k in (
+            "MILVUS_URI",
+            "MILVUS_TOKEN",
+            "MILVUS_USER",
+            "MILVUS_PASSWORD",
+            "ZILLIZ_URI",
+            "ZILLIZ_TOKEN",
+            "ZILLIZ_DB_USER",
+            "ZILLIZ_DB_PASSWORD",
+            "EMBEDDING_DIM",
+        )
+        if k in os.environ
+    }
+    if not (env.get("MILVUS_URI") or env.get("ZILLIZ_URI")):
+        pytest.skip(
+            "MILVUS_URI / ZILLIZ_URI not set; live Milvus tests skipped."
+        )
+    # Normalise to the names MilvusConfig.from_env expects.
+    if "MILVUS_URI" in env and "ZILLIZ_URI" not in env:
+        env["ZILLIZ_URI"] = env["MILVUS_URI"]
+    if "MILVUS_TOKEN" in env and "ZILLIZ_TOKEN" not in env:
+        env["ZILLIZ_TOKEN"] = env["MILVUS_TOKEN"]
+    return env
+
+
+@pytest.fixture
+def milvus_store():
+    """Yield a MilvusVectorStore bound to a per-test sentinel collection."""
+    env = _milvus_env()
+    collection = f"test_kg_entities_{uuid.uuid4().hex[:8]}"
+    env["ZILLIZ_COLLECTION"] = collection
+    env.setdefault("EMBEDDING_DIM", "4")  # tiny dim for fast schema bootstrap
+
+    cfg = MilvusConfig.from_env(env)
+    store = MilvusVectorStore(cfg)
+    try:
+        yield store
+    finally:
+        # Best-effort cleanup; a leaked sentinel is loud-but-harmless.
+        try:
+            store.drop()
+        except Exception as exc:  # noqa: BLE001 — defensive teardown
+            import warnings
+
+            warnings.warn(f"Milvus sentinel cleanup failed: {exc}")
+
+
+def test_health_via_count_zero_on_fresh_collection(milvus_store):
+    """Smoke probe: the live cluster responds + a fresh collection is empty."""
+    assert milvus_store.count() == 0
+
+
+def test_upsert_then_query_returns_entry(milvus_store):
+    """Round-trip a tiny vector through the live cluster."""
+    milvus_store.upsert(
+        [
+            VectorEntry(
+                entity_id="ent-roundtrip",
+                vector=[1.0, 0.0, 0.0, 0.0],
+                entity_name="RoundTrip",
+                content="probe entity for live Milvus",
+                source_id="integration:probe",
+                file_path="test",
+                scope="shared",
+            ),
+        ]
+    )
+    # Milvus's flush-on-search is eventual; the search call below
+    # waits for consistent read by default.
+    hits = milvus_store.query([1.0, 0.0, 0.0, 0.0], top_k=1)
+    assert len(hits) == 1
+    assert hits[0].entry.entity_id == "ent-roundtrip"
+    assert hits[0].entry.source_id == "integration:probe"
+
+
+def test_scope_filter_excludes_other_scopes(milvus_store):
+    """The metadata-filter path actually filters at the cluster level."""
+    milvus_store.upsert(
+        [
+            VectorEntry(
+                entity_id="ent-shared",
+                vector=[0.0, 1.0, 0.0, 0.0],
+                entity_name="Shared",
+                scope="shared",
+            ),
+            VectorEntry(
+                entity_id="ent-private",
+                vector=[0.0, 1.0, 0.0, 0.0],
+                entity_name="Private",
+                scope="tenant-foo",
+            ),
+        ]
+    )
+    shared_hits = milvus_store.query([0.0, 1.0, 0.0, 0.0], top_k=5, scope="shared")
+    shared_ids = {h.entry.entity_id for h in shared_hits}
+    assert "ent-shared" in shared_ids
+    assert "ent-private" not in shared_ids


### PR DESCRIPTION
Final slice of the **LightRAG vectors → Zilliz Milvus** migration stack.

## Summary

- **Phase 5 — tests**
  - \`mcp/tests/integration/test_milvus_vectorstore.py\` — live integration against Zilliz/Milvus. Sentinel collection per-test, dropped on teardown. Skips cleanly without \`ZILLIZ_URI\`.
  - \`mcp/tests/e2e/test_agentic_kg_query.py\` — single-turn agentic loop via the bare Anthropic SDK. Asserts the agent's reply cites a documented provenance \`source_id\`.
- **Phase 6 — CI + deploy**
  - \`deploy-mcp.yml\` — header documents the new Railway env requirements (\`ZILLIZ_URI\`, \`ZILLIZ_TOKEN\`, \`KG_VECTOR_BACKEND\`).
  - \`mcp-ci.yml\` — new \`milvus-integration\` job mirrors the \`aura-data-integrity\` pattern.
  - \`pyproject.toml\` — \`[project.optional-dependencies] agentic = ["anthropic>=0.40"]\`.

## Test plan

- [x] 144/144 unit tests still pass; 4 new gated tests collected.
- [ ] CI green.
- [ ] **Operator runbook (after merge):**
  - [ ] Set \`ZILLIZ_URI\` in Infisical \`/mcp/kg/\`.
  - [ ] Mirror Zilliz secrets to Railway prod env.
  - [ ] Mirror to GH repo secrets (\`ZILLIZ_URI\`, \`ZILLIZ_TOKEN\`) for the milvus-integration CI job.
  - [ ] Run \`migrate_nano_to_milvus.py --dry-run\` then commit.
  - [ ] Set \`KG_VECTOR_BACKEND=milvus\` in Railway → re-deploy.
  - [ ] **Rotate the chat-leaked Zilliz creds.**

## Risk

Low. New CI job is fork-safe (skips on missing secret). Deploy YAML changes are doc-only.