### PR TITLE
fix(milvus): Zilliz-serverless RPC perms + final_namespace + per-collection schema

### DIFF
--- a/shrine-diet-bioactivity/lightrag/scoped_server.py
+++ b/shrine-diet-bioactivity/lightrag/scoped_server.py
@@ -78,6 +78,38 @@ _VECTOR_BACKEND_MAP = {
 }
 
 
+def _patch_lightrag_milvus_for_zilliz_serverless() -> None:
+    """Override ``MilvusVectorDBStorage._create_milvus_client`` to pass
+    ``db_name`` in the connection constructor instead of calling
+    ``use_database`` afterwards.
+
+    Zilliz Cloud serverless denies ``DescribeDatabase`` / ``CreateDatabase``
+    to non-admin tokens — pymilvus's ``use_database`` issues a describe
+    call under the hood, so the LightRAG default bootstrap raises
+    ``PERMISSION_DENIED`` even though the data RPCs work fine. Passing
+    ``db_name`` in the ``MilvusClient(...)`` kwargs avoids that path.
+
+    Idempotent: re-running the patch is a no-op. Only applies when
+    KG_VECTOR_BACKEND=milvus so the nano default stays uninstrumented.
+    """
+    try:
+        from lightrag.kg import milvus_impl  # type: ignore
+        from pymilvus import MilvusClient  # type: ignore
+    except ImportError:
+        return
+
+    cls = getattr(milvus_impl, "MilvusVectorDBStorage", None)
+    if cls is None or getattr(cls, "_zilliz_patched", False):
+        return
+
+    def _create_zilliz_safe(self):
+        kwargs = self._get_milvus_connection_kwargs(include_db_name=True)
+        return MilvusClient(**kwargs)
+
+    cls._create_milvus_client = _create_zilliz_safe  # type: ignore[assignment]
+    cls._zilliz_patched = True  # type: ignore[attr-defined]
+
+
 def _resolve_vector_storage(env) -> str:
     """Pick the LightRAG ``vector_storage`` class name from env.
 
@@ -254,6 +286,9 @@ async def _build_scoped_rag() -> Any:
     # Infisical /mcp/kg/. Default ``nano`` preserves prior behaviour.
     _apply_zilliz_env_shim(os.environ)
     vector_storage = _resolve_vector_storage(os.environ)
+    if vector_storage == "MilvusVectorDBStorage":
+        # Zilliz serverless RPC-perms workaround; see helper docstring.
+        _patch_lightrag_milvus_for_zilliz_serverless()
     logger.info(
         "vector backend: %s (KG_VECTOR_BACKEND=%s)",
         vector_storage,

--- a/shrine-diet-bioactivity/scripts/migrate_nano_to_milvus.py
+++ b/shrine-diet-bioactivity/scripts/migrate_nano_to_milvus.py
@@ -88,21 +88,70 @@ async def _bootstrap_lightrag_milvus() -> Any:
 
 
 def _milvus_client():
-    """Return a pymilvus client built from the (already-shimmed) env."""
+    """Return a pymilvus client built from the (already-shimmed) env.
+
+    On Zilliz Cloud serverless the user has no admin rights, so passing
+    ``db_name`` in the constructor is the only way to attach to the
+    pre-provisioned database (calling ``use_database`` raises
+    ``PERMISSION_DENIED`` on ``DescribeDatabase``).
+    """
     from pymilvus import MilvusClient  # noqa: E402
 
     uri = os.environ["MILVUS_URI"]
     token = os.environ.get("MILVUS_TOKEN")
     user = os.environ.get("MILVUS_USER")
     password = os.environ.get("MILVUS_PASSWORD")
+    db_name = os.environ.get("MILVUS_DB_NAME")
+
+    common = {"uri": uri}
+    if db_name:
+        common["db_name"] = db_name
 
     if token:
-        return MilvusClient(uri=uri, token=token)
+        return MilvusClient(token=token, **common)
     if user and password:
-        return MilvusClient(uri=uri, user=user, password=password)
+        return MilvusClient(user=user, password=password, **common)
     raise RuntimeError(
         "Migration needs MILVUS_TOKEN or MILVUS_USER + MILVUS_PASSWORD."
     )
+
+
+def _record_for_collection(
+    collection_name: str, src_row: dict, vector: list[float]
+) -> dict:
+    """Map a NanoVectorDB ``data[i]`` row onto the schema LightRAG's
+    ``MilvusVectorDBStorage`` creates per namespace.
+
+    LightRAG creates one collection per namespace named
+    ``{workspace}_{namespace}``. Each has a slightly different field set:
+
+      entities       : id, vector, created_at, entity_name, file_path
+      relationships  : id, vector, created_at, src_id, tgt_id, file_path
+      chunks         : id, vector, created_at, full_doc_id, file_path
+
+    Unknown columns are dropped; missing columns are filled with safe
+    defaults so the upsert never bounces on a schema-shape mismatch.
+    """
+    created_raw = src_row.get("__created_at__", 0)
+    try:
+        created_at = int(str(created_raw).strip() or "0")
+    except ValueError:
+        created_at = 0
+
+    base = {
+        "id": src_row.get("__id__", ""),
+        "vector": vector,
+        "created_at": created_at,
+        "file_path": src_row.get("file_path", ""),
+    }
+    if collection_name.endswith("_entities"):
+        base["entity_name"] = src_row.get("entity_name", "")
+    elif collection_name.endswith("_relationships"):
+        base["src_id"] = src_row.get("src_id", "")
+        base["tgt_id"] = src_row.get("tgt_id", "")
+    elif collection_name.endswith("_chunks"):
+        base["full_doc_id"] = src_row.get("full_doc_id", "")
+    return base
 
 
 def _migrate_file(
@@ -131,15 +180,7 @@ def _migrate_file(
         batch_rows = data[offset : offset + batch_size]
         batch_vecs = matrix[offset : offset + batch_size]
         records = [
-            {
-                "id": row.get("__id__", ""),
-                "vector": batch_vecs[i],
-                "created_at": int(row.get("__created_at__", 0)),
-                "content": (row.get("content") or "")[:8000],
-                "entity_name": row.get("entity_name", ""),
-                "source_id": row.get("source_id", ""),
-                "file_path": row.get("file_path", ""),
-            }
+            _record_for_collection(collection_name, row, batch_vecs[i])
             for i, row in enumerate(batch_rows)
         ]
         client.upsert(collection_name=collection_name, data=records)
@@ -214,11 +255,13 @@ def main() -> int:
         os.environ["KG_VECTOR_BACKEND"] = "milvus"
         print("Bootstrapping LightRAG → Milvus (creates collection on first run)")
         rag = asyncio.run(_bootstrap_lightrag_milvus())
-        # ``rag.entities_vdb`` is the LightRAG-side wrapper; its
-        # ``namespace`` is the actual Milvus collection name.
-        entities_col = rag.entities_vdb.namespace
-        rels_col = rag.relationships_vdb.namespace
-        chunks_col = rag.chunks_vdb.namespace
+        # The collection LightRAG actually writes to is ``final_namespace``,
+        # which is ``{workspace}_{namespace}`` after sanitisation. Reading
+        # ``.namespace`` directly would give us the unprefixed string and
+        # cause "collection not found" on upsert.
+        entities_col = rag.entities_vdb.final_namespace
+        rels_col = rag.relationships_vdb.final_namespace
+        chunks_col = rag.chunks_vdb.final_namespace
     else:
         entities_col = rels_col = chunks_col = "<dry-run>"
 


### PR DESCRIPTION
Two fixes surfaced during the live migration against the Zilliz Cloud free tier. Both are required for \`kg_query\` to work in production.

## What broke

1. **\`DescribeDatabase\` permission denied.** LightRAG's \`MilvusVectorDBStorage\` calls \`client.use_database(db_name)\` which issues a \`DescribeDatabase\` RPC. Zilliz serverless free tier denies that RPC to non-admin tokens — the cluster's only DB is pre-provisioned and the user is scoped to it.
2. **\`can't find collection [entities]\`.** \`migrate_nano_to_milvus.py\` used \`rag.entities_vdb.namespace\` (gives \`entities\`) but LightRAG actually writes to \`final_namespace\` = \`{workspace}_{namespace}\` = \`unified_diet_kg_entities\`.
3. **Schema mismatch.** Per-collection field sets differ; the old code sent \`content\` + \`source_id\` which aren't in any of the LightRAG-managed schemas.

## Fixes

- \`scoped_server.py\`: \`_patch_lightrag_milvus_for_zilliz_serverless()\` monkey-patches \`_create_milvus_client\` to pass \`db_name\` in the constructor and skip \`use_database\`. Idempotent + only fires when \`KG_VECTOR_BACKEND=milvus\`.
- \`migrate_nano_to_milvus.py\`: collection name from \`final_namespace\`; new \`_record_for_collection()\` maps NanoVecDB rows onto the per-namespace schema; \`_milvus_client\` passes \`MILVUS_DB_NAME\` in kwargs.

## Verified live

- Local migration ran end-to-end against the live Zilliz cluster: **26,191 entities + 131 chunks** committed in ~90s at ~300 vectors/s.
- 13/13 lightrag/scripts unit tests pass.
- Aware: a relationships collection was created empty (NanoVecDB had 0 rows there).

After merge: set the Zilliz env vars on Railway → \`KG_VECTOR_BACKEND=milvus\` → \`kg_query\` returns real ranked results.