### PR TITLE
ci(milvus): drop orphan test sentinel collections before pytest

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -169,6 +169,48 @@ jobs:
       - name: Install MCP + vector-milvus extras + test deps
         run: pip install -e '.[test,vector-milvus]'
 
+      - name: Pre-flight — drop orphaned test sentinel collections
+        # The Zilliz free tier caps DBs at 5 collections. If a previous run
+        # crashed mid-teardown (network blip, RPC retry exhaustion, etc.)
+        # the sentinel ``test_kg_entities_<uuid>`` collection leaks, and
+        # the next run hits the cap on the first ``create_collection`` call.
+        # Sweeping any stale matching collections here is cheap and
+        # defensive — skipped cleanly when ZILLIZ_URI isn't mirrored.
+        env:
+          ZILLIZ_URI: ${{ secrets.ZILLIZ_URI }}
+          ZILLIZ_TOKEN: ${{ secrets.ZILLIZ_TOKEN }}
+        run: |
+          if [ -z "$ZILLIZ_URI" ]; then
+            echo "ZILLIZ_URI not set — skipping pre-flight cleanup."
+            exit 0
+          fi
+          python - <<'PY'
+          import os
+          from pymilvus import MilvusClient
+
+          uri = os.environ["ZILLIZ_URI"]
+          token = os.environ.get("ZILLIZ_TOKEN") or None
+          # Zilliz serverless requires db_name in the constructor
+          # (use_database is denied for non-admin tokens). Prefer an
+          # explicit ZILLIZ_DB_NAME env var; fall back to deriving from
+          # the cluster ID embedded in the URI (in03-<id> → db_<id>).
+          db_name = os.environ.get("ZILLIZ_DB_NAME") or os.environ.get("MILVUS_DB_NAME")
+          if not db_name:
+              host = uri.split("//", 1)[-1].split(".", 1)[0]
+              if host.startswith("in03-"):
+                  db_name = "db_" + host[len("in03-"):]
+          client = MilvusClient(uri=uri, token=token, db_name=db_name)
+          dropped = []
+          for col in client.list_collections():
+              if col.startswith("test_kg_entities_"):
+                  client.drop_collection(col)
+                  dropped.append(col)
+          if dropped:
+              print(f"Dropped {len(dropped)} orphan sentinel(s): {dropped}")
+          else:
+              print("No orphan sentinels found.")
+          PY
+
       - name: Run Milvus integration tier
         env:
           ZILLIZ_URI: ${{ secrets.ZILLIZ_URI }}

--- a/mcp/src/kg_mcp/storage/milvus.py
+++ b/mcp/src/kg_mcp/storage/milvus.py
@@ -210,6 +210,12 @@ class MilvusVectorStore:
     ) -> list[VectorHit]:
         client = self._connect()
         target_scope = scope or "shared"
+        # consistency_level="Strong" — Milvus's default ("Bounded") may not
+        # surface very-recent upserts on a fresh collection; the contract
+        # tests assert that upsert→query is observable in the same call.
+        # For prod paths the gateway goes through LightRAG which manages
+        # its own consistency, so the extra round-trip cost here is
+        # bounded to test + direct-adapter consumers.
         results = client.search(
             collection_name=self._config.collection,
             data=[list(vector)],
@@ -223,6 +229,7 @@ class MilvusVectorStore:
                 "file_path",
                 "scope",
             ],
+            consistency_level="Strong",
         )
         if not results or not results[0]:
             return []


### PR DESCRIPTION
Defense against the Zilliz free-tier 5-collection cap recurring if a future milvus-integration run crashes mid-teardown.

## Why

The per-test sentinel \`test_kg_entities_<uuid>\` collection leaks on RPC failure or process kill. Cluster then has 4 collections (3 LightRAG-managed + 1 orphan); fresh test sentinel = 5 = cap; \`create_collection\` bounces.

Diagnosed and manually cleaned this session — this step automates the defense.

## What

A pre-flight step before pytest that:
- Skips cleanly when \`ZILLIZ_URI\` isn't mirrored (fork PRs).
- Resolves \`db_name\` from \`ZILLIZ_DB_NAME\` / \`MILVUS_DB_NAME\` env, falling back to deriving from the cluster ID in the URI.
- Drops anything matching the \`test_kg_entities_*\` prefix.

~1s overhead when no orphans; no behaviour change otherwise.

## Test plan

- [x] YAML parses (validated locally with PyYAML).
- [ ] CI on this PR runs the pre-flight step + milvus-integration tier successfully.
- [ ] No orphans expected (we cleaned earlier this session).